### PR TITLE
Reach wallet arcs (0005 thru 0011)

### DIFF
--- a/ARCs/arc-0005.md
+++ b/ARCs/arc-0005.md
@@ -1,0 +1,66 @@
+---
+arc: 5
+title: Algorand Wallet Transaction Signing API (Functionality Only)
+status: Draft
+---
+
+# Algorand Wallet Transaction Signing API (Functionality Only)
+
+> This API is a draft.
+> Some elements may change.
+> This ARC is intended to be completely compatible with [ARC-0001](ARC-0001.md).
+
+## Summary
+
+An API for a function used to sign a list of transactions on the Algorand blockchain.
+
+## Abstract
+
+[ARC-0001](ARC-0001.md) defines a standard for signing transactions with security in mind. This proposal is a strict subset of ARC-0001 that outlines only the minimum functionality required in order to be useable.
+
+Wallets that conform to ARC-0001 already conform to this API.
+
+## Specification
+
+### Interface `SignTxnFunction`
+
+```ts
+export type SignTxnFunction = (
+   txns: WalletTransaction[],
+   opts?: any,
+)
+   => Promise<(string | null)[]>;
+```
+
+A `SignTxnFunction`:
+
+* MAY expect `txns` to be in the correct format as specified by `WalletTransaction`.
+
+### Interface `WalletTransaction`
+
+```ts
+export interface WalletTransaction {
+   /**
+    * Base64 encoding of the canonical msgpack encoding of a Transaction.
+    */
+   txn: string;
+}
+```
+
+### Semantic requirements
+
+* The call `signTxn(txns, opts)` MUST either throw an error or return an array `ret` of the same length as the `txns` array.
+* Each element of `ret` MUST be the base64 encoding of the canonical msgpack encoding of the `SignedTxn` corresponding object, as defined in the [Algorand specs](https://github.com/algorandfoundation/specs).
+
+## Rationale
+
+This simplified version of ARC-0001 exists for two main reasons:
+
+1. To outline the minimum amount of functionality needed in order to be useful.
+2. To serve as a stepping stone towards full ARC-0001 compatibility.
+
+While users would be wise to select a wallet that fully adheres to ARC-0001, this simplified API sets a lower bar and acts as a signpost for which wallets can even be used at all.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/ARCs/arc-0006.md
+++ b/ARCs/arc-0006.md
@@ -66,6 +66,7 @@ When `network` is specified in `opts`:
 When `network` is not specified in `opts`:
 
 * The user SHOULD be prompted to select the network they wish to use.
+* The call `enable(opts)` MUST either throw an error or return an object `ret` where `ret.network` SHOULD represent the user's selection of network and MUST adhere to the `NetworkIdentifier` string format.
 * The function MAY throw an error if it does not support user selection of network.
 
 When `accounts` is specified in `opts`:

--- a/ARCs/arc-0006.md
+++ b/ARCs/arc-0006.md
@@ -1,0 +1,90 @@
+---
+arc: 6
+title: Algorand Wallet Address Discovery API
+status: Draft
+---
+
+# Algorand Wallet Address Discovery API
+
+> This API is a draft.
+> Some elements may change.
+
+## Summary
+
+An API for a function used to discover the addresses a wallet user is willing to use for a given Algorand DApp.
+
+## Abstract
+
+A function, `enable`, which allows the discovery of accounts. This document requires nothing else, but further semantic meaning is prescribed to `enable` in [ARC-0010](ARC-0010.md) which builds off of this one and a few others.
+
+## Specification
+
+### Interface `EnableFunction`
+
+```ts
+export type EnableFunction = (
+  opts?: EnableOpts
+) => Promise<EnableResult>;
+
+export interface EnableOpts = {
+  network?: string;    // NetworkIdentifier
+  accounts?: string[]; // AlgorandAddress[]
+}
+
+export interface EnableResult = {
+  network: string;    // NetworkIdentifier
+  accounts: string[]; // AlgorandAddress[]
+}
+```
+
+An `EnableFunction` with input argument `opts:EnableOpts` and return value `ret:EnableResult`:
+
+* MAY expect `opts.network` to be in the correct format as specified by `NetworkIdentifier`.
+* MAY expect `opts.accounts` to be in the correct format as specified by `AlgorandAddress`.
+* MUST return `network` in the format of `NetworkIdentifier`
+* MUST return `accounts` in the format of an array of `AlgorandAddress`
+
+### String specification: `NetworkIdentifier`
+
+A `NetworkIdentifier` string must be in the format `"${network}-${id}"`, such as `"testnet-v1.0"` and `"mainnet-v1.0"`.
+
+### String specification: `AlgorandAddress`
+
+Quoting [ARC-0001](ARC-0001.md):
+
+> An Algorand address is represented by a 58-character base32 string. It includes includes the checksum.
+
+### Semantic requirements
+
+Regarding a call to `enable(opts)` or `enable()` (where `opts` is `undefined`), with potential promised return value `ret`:
+
+When `network` is specified in `opts`:
+
+* The call `enable(opts)` MUST either throw an error or return an object `ret` where `ret.network` is identical to `opts.network`.
+* The user SHOULD be prompted for permission to acknowledge control of accounts on that specific network.
+
+When `network` is not specified in `opts`:
+
+* The user SHOULD be prompted to select the network they wish to use.
+* The function MAY throw an error if it does not support user selection of network.
+
+When `accounts` is specified in `opts`:
+
+* The call `enable(opts)` MUST either throw an error or return an object `ret` where `ret.accounts` is an array that starts with all the same elements as `opts.accounts`, in the same order.
+* When `accounts` are specified in the `opts`, the user SHOULD be prompted for permission to acknowledge their control of the specified accounts. The wallet MAY allow the user to provide more accounts than those listed.
+
+When `accounts` is not specified in `opts`:
+
+* The user SHOULD be prompted to select the accounts they wish to reveal on the selected network.
+* The call `enable(opts)` MUST either throw an error or return an object `ret` where `ret.accounts` is a non-empty array.
+* The caller MAY assume that `ret.accounts[0]` is the user's "currently-selected" or "default" account, for DApps that only require access to one account.
+
+## Rationale
+
+This API puts power in the user's hands to choose a preferred network and account to use when interacting with a DApp.
+
+It also allows DApp developers to suggest a specific network, or specific accounts, as appropriate. The user still maintains the ability to reject the DApp's suggestions, which corresponds to rejecting the promise returned by `enable()`.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/ARCs/arc-0007.md
+++ b/ARCs/arc-0007.md
@@ -1,0 +1,66 @@
+---
+arc: 7
+title: Algorand Wallet Post Transactions API
+status: Draft
+---
+
+# Algorand Wallet Post Transactions API
+
+> This API is a draft.
+> Some elements may change.
+
+## Summary
+
+An API for a function used to post transactions to the network.
+
+## Abstract
+
+A function, `postTxns`, which accepts an array of `SignedTransaction`s, and posts them to the network.
+
+## Specification
+
+### Interface `PostTxnsFunction`
+
+```ts
+export type PostTxnsFunction = (
+  stxns: string[], // SignedTxnStr
+) => Promise<PostTxnsResult>;
+
+export interface PostTxnsResult {
+  txId: string; // TxId
+}
+```
+
+A `PostTxnsFunction` with input argument `stxns:string[]` and promised return value `ret:PostTxnsResult`:
+
+* MAY expect `stxns` to be in the correct string format as specified by `SignedTxnStr`.
+* MUST, if successful, return an object `ret` such that `ret.txId` is in the correct string format as specified by `TransactionId`
+
+### String specification: `SignedTxnStr`
+
+Quoting ARC-0001:
+
+> [`SignedTxnStr` is] the base64 encoding of the canonical msgpack encoding of the `SignedTxn` corresponding object, as defined in the [Algorand specs](https://github.com/algorandfoundation/specs).
+
+### String specification: `TxId`
+
+A `TxId` is a 52-character base32 string.
+
+### Semantic requirements
+
+Regarding a call to `postTxns(stxns)` with promised return value `ret`:
+
+* `postTxns` MAY assume that `stxns` are in the correct format as specified by `SignedTxnStr`.
+* `postTxns` MUST attempt to post all transactions together.
+* If successful, `postTxns` MUST resolve the returned promise with the `TxId` received from the network. (This SHOULD be the transaction ID for the first transaction in the group.)
+* If unsuccessful, `postTxns` MUST reject the promise with an error. The error SHOULD describe what went wrong in as much detail as possible.
+
+## Rationale
+
+This API allows DApps to use a user's preferred connection in order to submit transactions to the network.
+
+The user may wish to use a specific trusted node, or a particular paid service with their own secret token. This API protects the user's secrets by not exposing connection details to the DApp.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/ARCs/arc-0008.md
+++ b/ARCs/arc-0008.md
@@ -1,0 +1,42 @@
+---
+arc: 8
+title: Algorand Wallet Sign and Post API
+status: Draft
+---
+
+# Algorand Wallet Sign and Post API
+
+> This API is a draft.
+> Some elements may change.
+
+## Summary
+
+An API for a function used to simultaneously sign and post transactions to the network.
+
+## Abstract
+
+A function `signAndPostTxns`, which accepts an array of `WalletTransaction`s, and posts them to the network.
+
+Accepts the inputs to [ARC-0005](arc-0005.md)'s `signTxns`, and produces the output of [ARC-0007](arc-0007.md)'s `postTxns`.
+
+## Specification
+
+### Interface `SignAndPostTxnsFunction`
+
+```ts
+export type SignAndPostTxnsFunction = (
+   txns: WalletTransaction[],
+   opts?: any,
+) => Promise<PostTxnsResult>;
+```
+
+* `WalletTransaction` is as specified by [ARC-0005](arc-0005.md).
+* `PostTxnsResult` is as specified by [ARC-0007](arc-0007.md).
+
+## Rationale
+
+Allows the user to be sure that what they are signing is in fact all that is being sent. Doesn't necessarily grant the DApp direct access to the signed txns, though they are posted to the network, so they should not be considered private.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/ARCs/arc-0008.md
+++ b/ARCs/arc-0008.md
@@ -37,6 +37,8 @@ export type SignAndPostTxnsFunction = (
 
 Allows the user to be sure that what they are signing is in fact all that is being sent. Doesn't necessarily grant the DApp direct access to the signed txns, though they are posted to the network, so they should not be considered private.
 
+Exposing only this API instead of exposing `postTxns` directly is potentially safer for the wallet user, since it only allows the posting of transactions which the user has explicitly approved.
+
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/ARCs/arc-0009.md
+++ b/ARCs/arc-0009.md
@@ -1,0 +1,47 @@
+---
+arc: 9
+title: Algorand Wallet Algodv2 and Indexer API
+status: Draft
+---
+
+# Algorand Wallet Algodv2 and Indexer API
+
+> This API is a draft.
+> Some elements may change.
+> Furthermore, this API is considered a stopgap solution.
+
+## Summary
+
+An API for accessing Algod and Indexer through a user's preferred connection.
+
+## Abstract
+
+Functions `getAlgodv2` and `getIndexer` which return the corresponding algosdk objects.
+
+## Specification
+
+### Interface `GetAlgodv2Function`
+
+```ts
+type GetAlgodv2Function = () => Promise<Algodv2>
+```
+
+Returns a promised `Algodv2`, where `Algodv2` is an interface matching the class `algosdk.Algodv2`.
+
+### Interface `GetIndexerFunction`
+
+```ts
+type GetIndexerFunction = () => Promise<Indexer>
+```
+
+Returns a promised `Indexer`, where `Indexer` is an interface matching the class `algosdk.Indexer`.
+
+## Rationale
+
+Nontrivial DApps often require the ability to query the network for activity. Algorand DApps written without regard to wallets are likely written using `Algodv2` and `Indexer` from `algosdk`. This document is a very blunt approach to exposing identical querying functionality through a wallet, making it easy for JavaScript DApp authors to port their code to work with wallets.
+
+We expect this document to be a stepping stone towards discovering better ways to expose the querying functionality that DApps need in order to function.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/ARCs/arc-0010.md
+++ b/ARCs/arc-0010.md
@@ -1,0 +1,90 @@
+---
+arc: 10
+title: Algorand Wallet Reach Minimum Requirements
+status: Draft
+---
+
+# Algorand Wallet Reach Minimum Requirements
+
+> This API is a draft.
+> Some elements may change.
+> Especially the part about LogicSigs.
+
+## Summary
+
+An amalgamation of APIs which comprise the minimum requirements for Reach to be able to function correctly with a given wallet.
+
+## Abstract
+
+A group of related functions:
+
+* `enable`
+* `signAndPostTxns`
+* `getAlgodv2`
+* `getIndexer`
+
+## Specification
+
+* `enable`: as specified in [ARC-0006](arc-0006.md).
+* `signAndPostTxns`: as specified in [ARC-0008](arc-0008.md).
+* `getAlgodv2` and `getIndexer`: as specified in [ARC-0009](arc-0009.md).
+
+There are additional semantics for using these functions together.
+
+### Semantic Requirements
+
+* `enable` SHOULD be called before calling the other functions.
+* If `signAndPostTxns`, `getAlgodv2`, or `getIndexer` are called before `enable`, they SHOULD throw an error.
+* `getAlgodv2` and `getIndexer` MUST return connections to the network indicated by the `network` result of `enable`.
+* `signAndPostTxns` MUST post transactions to the network indicated by the `network` result of `enable`
+* The result of `getAlgodv2` SHOULD only be used to query the network. `signAndPostTxns` SHOULD be used to send transactions to the network. The `Algodv2` object MAY be modified to throw exceptions if the caller tries to use it to post transactions.
+
+### Additional requirements regarding LogicSigs
+
+`signAndPostTxns` must also be able to handle logic sigs. Callers are expected to sign the logic sig by themselves, rather than expecting the wallet to do so on their behalf. To handle this case, we adopt and extend the [ARC-0001](arc-0001.md) format for `WalletTransaction`s that do not need to be signed:
+
+```json
+{
+  "txn": "...",
+  "signers": [],
+  "stxn": "..."
+}
+```
+
+* `stxn` is a `SignedTxnStr`, as specified in [ARC-0007](arc-0007.md).
+* This ARC will likely be updated or extended to require more information about the logic sig in order to allow the wallet to verify that `"txn"` and `"stxn"` match.
+
+## Rationale
+
+In order for a wallet to be useable by Reach, it must support features for account discovery, signing and posting transactions, and querying the network.
+
+To whatever extent possible, the end users of a DApp should be empowered to select their own wallet, accounts, and network to be used with the DApp. Furthermore, said users should be able to use their preferred network node connection, without exposing their connection details and secrets (such as endpoint URLs and API tokens) to the DApp.
+
+It is our intent that the APIs presented in this document and related documents are sufficient to cover the needed functionality, while protecting user choice and remaining compatible with best security practices.
+
+## Sample usage
+
+```js
+async function main(wallet) {
+
+  // Account discovery
+  const enabled = await wallet.enable({network: 'testnet-v1.0'});
+  const from = enabled.accounts[0];
+
+  // Querying
+  const algodv2 = await wallet.getAlgodv2();
+  const suggestedParams = await algodv2.getTransactionParams().do();
+  const txns = makeTxns(from, suggestedParams);
+
+  // Sign and post
+  const res = await wallet.signAndPost(txns);
+  console.log(res);
+
+};
+```
+
+Where `makeTxns` is comparable to what is seen in [ARC-0001](arc-0001.md)'s sample code.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/ARCs/arc-0011.md
+++ b/ARCs/arc-0011.md
@@ -23,8 +23,8 @@ A property `algorand` attached to the `window` browser object, with all the feat
 interface WindowAlgorand {
   enable: EnableFunction;
   signAndPostTxns: SignAndPostTxnsFunction;
-  getAlgodv2Function: GetAlgodv2Function;
-  getIndexerFunction: GetIndexerFunction;
+  getAlgodv2: GetAlgodv2Function;
+  getIndexer: GetIndexerFunction;
 }
 ```
 

--- a/ARCs/arc-0011.md
+++ b/ARCs/arc-0011.md
@@ -1,0 +1,39 @@
+---
+arc: 11
+title: Algorand Wallet Reach Browser Spec
+status: Draft
+---
+
+# Algorand Wallet Reach Browser Spec
+
+> This API is a draft.
+> Some elements may change.
+
+## Summary
+
+A common convention for DApps to discover Algorand wallets in browser code: `window.algorand`.
+
+## Abstract
+
+A property `algorand` attached to the `window` browser object, with all the features Reach requires of a wallet.
+
+## Specification
+
+```ts
+interface WindowAlgorand {
+  enable: EnableFunction;
+  signAndPostTxns: SignAndPostTxnsFunction;
+  getAlgodv2Function: GetAlgodv2Function;
+  getIndexerFunction: GetIndexerFunction;
+}
+```
+
+With the specifications and semantics for each function as stated in [ARC-0010](arc-0010.md).
+
+## Rationale
+
+DApps should be unopinionated about which wallet they are used with. End users should be able to inject their wallet of choice into the DApp. Therefore, in browser contexts, we reserve `window.algorand` for this purpose.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
I've also written a small runnable demo which demonstrates an implementation of all of the API functionality specified by this group of ARCs. [except for `window.algorand`, since it is a cli demo]

https://github.com/reach-sh/algo-demo-wallet