### PR TITLE
ARC-0003: Clarify URI rules and support for {id}

### DIFF
--- a/ARCs/arc-0003.md
+++ b/ARCs/arc-0003.md
@@ -34,12 +34,12 @@ The ASA parameters should follow the following conventions:
         * If the resulting asset name can fit the *Asset Name* field, then `<name>` **SHOULD** be equal to the name in the JSON metadata file.
         * If the resulting asset name cannot fit the *Asset Name* field, then `<name>` **SHOULD** be a reasonable shorten version of the name in the JSON metadata file.
 * *URL* (`au`): a URI pointing to a JSON metadata file
-    > Shai: why not call it URI?
-    > Fabrice: This is the name in the specs
-    * The URI **SHOULD** be persistent and allow to download the JSON Metadata file forever
-    * **RECOMMENDED** protocols (for compatibility and security): *https* and *ipfs*
-    >addie: what about I2P or arweave?
-    * **NOT RECOMMENDED** protocols: *http* (due to security concenrs)
+    * The URI **SHOULD** be persistent and allow to download the JSON Metadata file forever.
+    * If the string `{id}` exists in this URI or any other URI, clients **MUST** replace this with the asset ID in decimal form. The rules below applies after such a replacement.
+    * The URI **MUST** follow [RFC-3986](https://www.ietf.org/rfc/rfc3986.txt) and **MUST NOT** contain any whitespace character
+    * **RECOMMENDED** URI schemes (for compatibility and security): *https* and *ipfs*:
+        * When the file is stored on IPFS, the `ipfs://...` URI **SHOULD** be used. IPFS Gateway URI (such as `https://ipfs.io/ipfs/...`) **SHOULD NOT** be used.
+    * **NOT RECOMMENDED** URI schemes: *http* (due to security concerns)
 * *Asset Metadata* (`am`): the SHA256 digest of the JSON metadata file as a 32-byte string (as defined in [NIST FIPS 180-4](https://doi.org/10.6028/NIST.FIPS.180-4))
 
 There are no requirements regarding the manager account of the ASA, or its the reserve account, freeze account, or clawback account.
@@ -57,7 +57,9 @@ When the total number of units is larger than 1, the NFT is a *fractional NFT*.
 
 > The JSON Medata File schema follow the Ethereum Improvement Proposal [ERC-1155 Metadata URI JSON Schema](https://eips.ethereum.org/EIPS/eip-1155) with one important difference: it allows to specify metadata hashes of localized versions.
 
-> Contrary to ERC-1155, the URI does not support ID substitution. If the URI contains `{id}`, it will not be substituted.
+Similarly to ERC-1155, the URI does support ID substitution. If the URI contains `{id}`, clients **MUST** substitute it by the asset ID in *decimal*.
+
+> Contrary to ERC-1155, the ID is represented in decimal (instead of hexadecimal) to match what current APIs and block explorers use on the Algorand blockchain.
 
 The JSON Metadata schema is as follows:
 
@@ -98,7 +100,7 @@ An example of an ARC-3 Metadata JSON file follows. The properties array proposes
 {
 	"name": "My Picture",
 	"description": "Lorem ipsum...",
-	"image": "https:\/\/s3.amazonaws.com\/your-bucket\/images\/{id}.png",
+	"image": "https:\/\/s3.amazonaws.com\/your-bucket\/images\/MyPicture.png",
 	"properties": {
 		"simple_property": "example value",
 		"rich_property": {
@@ -125,7 +127,7 @@ An example of possible ASA parameters would be:
 
 * *Asset Unit*: `mypict` for example
 * *Asset Name*: `My Picture@arc3` or `arc3`
-* *URL*: `ipfs://QmWS1VAdMD353A6SDk9wNyvkT14kyCiZrNDYAad4w1tKqT` or `https://example.com/mypict`
+* *URL*: `ipfs://QmWS1VAdMD353A6SDk9wNyvkT14kyCiZrNDYAad4w1tKqT` or `https://example.com/mypict` or `https://arweave.net/MAVgEMO3qlqe-qHNVs00qgwwbCb6FY2k15vJP3gBLW4`
 * *Metadata Hash*: the 32 bytes of the SHA-256 digest of the above JSON file
 * *Total Number of Units*: 100
 * *Number of Digits after the Decimal Point*: 2


### PR DESCRIPTION
This Pull Request is meant to subsumes https://github.com/algorandfoundation/ARCs/pull/6 following the comments received.

The support for {id} substitution is added to allow later support
for storing asset metadata on chain like proposed in
https://github.com/algorandfoundation/ARCs/pull/6#issuecomment-882511661