### PR TITLE
ARC-0003: Rename NFT to Pure NFT and Clarify Text

### DIFF
--- a/ARCs/arc-0003.md
+++ b/ARCs/arc-0003.md
@@ -44,14 +44,19 @@ The ASA parameters should follow the following conventions:
 
 There are no requirements regarding the manager account of the ASA, or its the reserve account, freeze account, or clawback account.
 
-An ASA is said to be a *non-fungible token* (NFT) if and only if it has the following poperties:
+#### Pure and Fractional NFTs
 
-* *Total Number of Units* (`t`): **MUST** be a power of 10: 1, 10, 100, ...
-* *Number of Digits after the Decimal Point* (`dc`): **MUST** be so equal to the logarithm in base 10 of total number of units
+An ASA is said to be a *pure non-fungible token* (*pure NFT*) if and only if it has the following poperties:
+
+* *Total Number of Units* (`t`) **MUST** be 1. 
+* *Number of Digits after the Decimal Point* (`dc`) **MUST** be 0.
+
+An ASA is said to be a *fractional non-fungible token* (*fractional NFT*) if and only if it has the following properties:
+
+* *Total Number of Units* (`t`) **MUST** be a power of 10 larger than 1: 10, 100, 1000, ...
+* *Number of Digits after the Decimal Point* (`dc`) **MUST** be equal to the logarithm in base 10 of total number of units.
 
 > In other words, the total supply of the ASA is exactly 1.
-
-When the total number of units is larger than 1, the NFT is a *fractional NFT*.
 
 ### JSON Metadata File Schema
 


### PR DESCRIPTION
Since the community is split on the exact definition of NFTs, this PR proposes
to use a definition that leaves open the possibility to name "NFTs" ASAs that
are not strictly speaking NFTs (or pure NFT).