### PR TITLE
ARC-0003: Support for Integrity Properties

### DIFF
--- a/ARCs/arc-0003.md
+++ b/ARCs/arc-0003.md
@@ -82,6 +82,10 @@ The JSON Metadata schema is as follows:
             "type": "string",
             "description": "A URI pointing to a resource with mime type image/* representing the asset to which this token represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive."
         },
+        "image_integrity": {
+            "type": "string",
+            "description": "The SHA-256 digest of the file pointed by the URI image. The property value is a single SHA-256 integrity metadata as defined in the W3C subresource integrity specification (https://w3c.github.io/webappsec-subresource-integrity)."
+        },
         "properties": {
             "type": "object",
             "description": "Arbitrary properties. Values may be strings, numbers, object or arrays."
@@ -92,6 +96,26 @@ The JSON Metadata schema is as follows:
 
 The property `decimals` is **OPTIONAL**. If provided, it **MUST** match the ASA parameter `dt`.
 
+#### Integrity Properties
+
+Compared to ERC-1155, the metadata JSON schema allows to indicate digests of the files pointed by any URI field.
+This is to ensure the integrity of all the files referenced by the ASA.
+Concretly, every URI property `xxx` is allowed to have an optional associated property  `xxx_integrity` that specifies the digest of the file pointed by the URI.
+
+The digests are represented as a single SHA-256 integrity metadata as defined in the [W3C subresource integrity specification](https://w3c.github.io/webappsec-subresource-integrity).
+Details on how to generate those digests can be found on the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) (where `sha384` or `384` are to be replaced by `sha256` and `256` respectively as only SHA-256 is supported by this ARC).
+
+It is **RECOMMENDED** to specify all the `xxx_integrity` properties of all the `xxx` URI properties.
+
+> Note that the only URI property specified by this schema is `image`. 
+> However, other properties may be used by specific ASAs. 
+> For example, for commonly used properties `external_url`, `animation_url`, or `youtube_url`, digests of the corresponding files may be specified in properties `external_url_integrity`, `animation_url_integrity`, `youtube_url_integrity`.
+
+Any property with a name ending with `_integrity` **MUST** match a corresponding property containing a URI to a file with a matching digest.
+For example, if the property `hello_integrity` is specified, the property `hello` **MUST** exist and **MUST** be a URI pointing to a file with a digest equal to the digest specified by `hello_integrity`.
+
+#### Sample
+
 An example of an ARC-3 Metadata JSON file follows. The properties array proposes some SUGGESTED formatting for token-specific display properties and metadata.
 
 ```json
@@ -99,6 +123,7 @@ An example of an ARC-3 Metadata JSON file follows. The properties array proposes
 	"name": "My Picture",
 	"description": "Lorem ipsum...",
 	"image": "https:\/\/s3.amazonaws.com\/your-bucket\/images\/{id}.png",
+    "image_integrity": "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
 	"properties": {
 		"simple_property": "example value",
 		"rich_property": {
@@ -138,6 +163,7 @@ If the metadata JSON file contains a `localization` attribute, its content **MAY
 
 > Compared to ERC-1155, the `localization` attribute contains an additional optional `integrity` field that specify the digests of the localized JSON files.
 
+
 ##### JSON Schema
 
 ```json
@@ -160,6 +186,10 @@ If the metadata JSON file contains a `localization` attribute, its content **MAY
         "image": {
             "type": "string",
             "description": "A URI pointing to a resource with mime type image/* representing the asset to which this token represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive."
+        },
+        "image_integrity": {
+            "type": "string",
+            "description": "The SHA-256 digest of the file pointed by the URI image. The property value is a single SHA-256 integrity metadata as defined in the W3C subresource integrity specification (https://w3c.github.io/webappsec-subresource-integrity)."
         },
         "properties": {
             "type": "object",
@@ -238,7 +268,7 @@ These conventions are heavily based on Ethereum Improvement Proposal [ERC-1155 M
 
 * Asset Name and Asset Unit can be optionally specified in the ASA parameters. This is to allow wallets that are not aware of ARC-3 or that are not able to retrieve the JSON file to still display meaningful information.
 * The SHA-256 digest of the JSON Metadata file is included in the ASA parameters to ensure integrity of this file. This is redundant with the URI when IPFS is used. But this is important to ensure the integrity of the JSON file when IPFS is not used.
-* Similarly, the JSON Metadata schema is changed to allow to specify the SHA-256 digests of the localized versions.
+* Similarly, the JSON Metadata schema is changed to allow to specify the SHA-256 digests of the localized versions as well as the SHA-256 digests of any file pointed by a URI property.
 
 The asset name is either `arc3` or suffixed by `@arc3` to allow client software to know when an asset follows the conventions.
 


### PR DESCRIPTION
Currently, there is no easy way to check the integrity of files
pointed by the metadata JSON. In particular, when buying an
NFT, the seller may then change for example the image of the
NFT without the buyer having anyway to prove that the image
actually changed.

This PR proposes to fix this issue by adding additional integrity
properties.