### PR TITLE
ARC-0003 Support for Extra Metadata

### DIFF
--- a/ARCs/arc-0003.md
+++ b/ARCs/arc-0003.md
@@ -40,7 +40,18 @@ The ASA parameters should follow the following conventions:
     * **RECOMMENDED** protocols (for compatibility and security): *https* and *ipfs*
     >addie: what about I2P or arweave?
     * **NOT RECOMMENDED** protocols: *http* (due to security concenrs)
-* *Asset Metadata* (`am`): the SHA256 digest of the JSON metadata file as a 32-byte string (as defined in [NIST FIPS 180-4](https://doi.org/10.6028/NIST.FIPS.180-4))
+* *Asset Metadata (Hash)* (`am`): 
+    * If the JSON metadata file specifies extra metadata `e` (property `extra_metadata`), then `am` is defined as:
+
+        ```plain
+        am = SHA-512/256("arc0003/am" || SHA-512/256("arc0003/amj" || content of JSON metadata file) || e)
+        ```
+
+        where `||` denotes concatenation and SHA-512/256 is defined in [NIST FIPS 180-4](https://doi.org/10.6028/NIST.FIPS.180-4).
+        The above definition of `am` **MUST** be used when the property `extra_metadata` is specified, even if its value `e` is the empty string.
+        Python code to compute the hash and a full example are provided below (see "Sample with Extra Metadata").
+        > Extra metadata can be used to store data about the asset that needs to be accessed from a smart contract. The smart contract would not be able to directly read the metadata. But, if provided with the hash of the JSON metadata file and with the extra metadata `e`, the smart contract can check that `e` is indeed valid.
+    * If the JSON metadata file does not specify the property `extra_metadata`, then `am` is defined as the SHA-256 digest of the JSON metadata file as a 32-byte string (as defined in [NIST FIPS 180-4](https://doi.org/10.6028/NIST.FIPS.180-4))
 
 There are no requirements regarding the manager account of the ASA, or its the reserve account, freeze account, or clawback account.
 
@@ -58,6 +69,8 @@ When the total number of units is larger than 1, the NFT is a *fractional NFT*.
 > The JSON Medata File schema follow the Ethereum Improvement Proposal [ERC-1155 Metadata URI JSON Schema](https://eips.ethereum.org/EIPS/eip-1155) with one important difference: it allows to specify metadata hashes of localized versions.
 
 > Contrary to ERC-1155, the URI does not support ID substitution. If the URI contains `{id}`, it will not be substituted.
+
+> Compared to ERC-1155, the schema allows for extra metadata that is hashed as part of the asset metadata (`am`) of the ASA.
 
 The JSON Metadata schema is as follows:
 
@@ -78,6 +91,10 @@ The JSON Metadata schema is as follows:
             "type": "string",
             "description": "Describes the asset to which this token represents"
         },
+        "extra_metadata": {
+            "type": "string",
+            "description": "Extra metadata in base64. If the property is specified (even if it is an empty string) the asset metadata (am) of the ASA is computed differently than if it is not specified."
+        },
         "image": {
             "type": "string",
             "description": "A URI pointing to a resource with mime type image/* representing the asset to which this token represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive."
@@ -91,6 +108,8 @@ The JSON Metadata schema is as follows:
 ```
 
 The property `decimals` is **OPTIONAL**. If provided, it **MUST** match the ASA parameter `dt`.
+
+#### Sample
 
 An example of an ARC-3 Metadata JSON file follows. The properties array proposes some SUGGESTED formatting for token-specific display properties and metadata.
 
@@ -132,6 +151,50 @@ An example of possible ASA parameters would be:
 
 The above parameters define a fractional NFT with 100 shares.
 
+#### Sample with Extra Metadata
+
+An example of an ARC-3 JSON Metadata file with extra metadata is provided below.
+
+```json
+{
+	"name": "My Picture",
+	"description": "Lorem ipsum...",
+	"image": "https://s3.amazonaws.com/your-bucket/images/MyPicture.png",
+    "extra_metadata": "iHcUslDaL/jEM/oTxqEX++4CS8o3+IZp7/V5Rgchqwc=",
+}
+```
+
+The possible ASA parameters are the same as with the previous example, except for the metadata hash that would be the 32-byte string corresponding to the base64 string `aoKbNjrLXaeqI6eynopp//tfwmdS6s7XfRMOjK2L9jA=`.
+
+> For completeness, we provide below a Python program that computes this metadata hash:
+```python
+import base64
+import hashlib
+
+extra_metadata_base64 = "iHcUslDaL/jEM/oTxqEX++4CS8o3+IZp7/V5Rgchqwc="
+extra_metadata = base64.b64decode(extra_metadata_base64)
+json_metadata = """{
+	"name": "My Picture",
+	"description": "Lorem ipsum...",
+	"image": "https://s3.amazonaws.com/your-bucket/images/MyPicture.png",
+    "extra_metadata": "iHcUslDaL/jEM/oTxqEX++4CS8o3+IZp7/V5Rgchqwc=",
+}"""
+
+h = hashlib.new("sha512_256")
+h.update(b"arc0003/amj")
+h.update(json_metadata.encode("utf-8"))
+json_metadata_hash = h.digest()
+
+h = hashlib.new("sha512_256")
+h.update(b"arc0003/am")
+h.update(json_metadata_hash)
+h.update(extra_metadata)
+am = h.digest()
+
+print("Asset metadata in base64: ")
+print(base64.b64encode(am).decode("utf-8"))
+```
+
 #### Localization
 
 If the metadata JSON file contains a `localization` attribute, its content **MAY** be used to provide localized values for fields that need it. The `localization` attribute should be a sub-object with three **REQUIRED** attributes: `uri`, `default`, `locales`, and one **RECOMMENDED** attribute: `integrity`. If the string `{locale}` exists in any URI, it **MUST** be replaced with the chosen locale by all client software.
@@ -156,6 +219,10 @@ If the metadata JSON file contains a `localization` attribute, its content **MAY
         "description": {
             "type": "string",
             "description": "Describes the asset to which this token represents"
+        },
+        "extra_metadata": {
+            "type": "string",
+            "description": "Extra metadata in base64. If the property is specified (even if it is an empty string) the asset metadata (am) of the ASA is computed differently than if it is not specified."
         },
         "image": {
             "type": "string",
@@ -237,8 +304,9 @@ fr.json:
 These conventions are heavily based on Ethereum Improvement Proposal [ERC-1155 Metadata URI JSON Schema](https://eips.ethereum.org/EIPS/eip-1155) to facilitate interoperobility. The main differences are highlighted below:
 
 * Asset Name and Asset Unit can be optionally specified in the ASA parameters. This is to allow wallets that are not aware of ARC-3 or that are not able to retrieve the JSON file to still display meaningful information.
-* The SHA-256 digest of the JSON Metadata file is included in the ASA parameters to ensure integrity of this file. This is redundant with the URI when IPFS is used. But this is important to ensure the integrity of the JSON file when IPFS is not used.
+* A digest of the JSON Metadata file is included in the ASA parameters to ensure integrity of this file. This is redundant with the URI when IPFS is used. But this is important to ensure the integrity of the JSON file when IPFS is not used.
 * Similarly, the JSON Metadata schema is changed to allow to specify the SHA-256 digests of the localized versions.
+* When extra metadata are provided, the asset metadata parameter is computed using SHA-512/256 with prefix for proper domain separation. SHA-512/256 is the hash function used in Algorand in general (see the list of prefixes in https://github.com/algorand/go-algorand/blob/master/protocol/hash.go). Domain separation is especially important in this case to avoid mixing hash of the metadata JSON file with extra metadata. However, since SHA-512/256 is less common and since not every tool or library allows to compute SHA-512/256, when no extra metadata is specified, SHA-256 is used instead.
 
 The asset name is either `arc3` or suffixed by `@arc3` to allow client software to know when an asset follows the conventions.
 

--- a/ARCs/arc-0003.md
+++ b/ARCs/arc-0003.md
@@ -167,11 +167,11 @@ An example of an ARC-3 JSON Metadata file with extra metadata is provided below.
 	"name": "My Picture",
 	"description": "Lorem ipsum...",
 	"image": "https://s3.amazonaws.com/your-bucket/images/MyPicture.png",
-    "extra_metadata": "iHcUslDaL/jEM/oTxqEX++4CS8o3+IZp7/V5Rgchqwc=",
+	"extra_metadata": "iHcUslDaL/jEM/oTxqEX++4CS8o3+IZp7/V5Rgchqwc=",
 }
 ```
 
-The possible ASA parameters are the same as with the previous example, except for the metadata hash that would be the 32-byte string corresponding to the base64 string `aoKbNjrLXaeqI6eynopp//tfwmdS6s7XfRMOjK2L9jA=`.
+The possible ASA parameters are the same as with the previous example, except for the metadata hash that would be the 32-byte string corresponding to the base64 string `RwtAnL/6YbmR0I2oAeU/vl6yusgBZvooQqxh4kjY6Xk=`.
 
 > For completeness, we provide below a Python program that computes this metadata hash:
 ```python
@@ -184,7 +184,7 @@ json_metadata = """{
 	"name": "My Picture",
 	"description": "Lorem ipsum...",
 	"image": "https://s3.amazonaws.com/your-bucket/images/MyPicture.png",
-    "extra_metadata": "iHcUslDaL/jEM/oTxqEX++4CS8o3+IZp7/V5Rgchqwc=",
+	"extra_metadata": "iHcUslDaL/jEM/oTxqEX++4CS8o3+IZp7/V5Rgchqwc=",
 }"""
 
 h = hashlib.new("sha512_256")


### PR DESCRIPTION
Previous version did not allow to store data that a smart contract could
access. This PR adds the option to hash extra metadata in the asset
metadata ASA parameter.