### PR TITLE
ARC-0003: Adding MIME types and OpenSea fields

### DIFF
--- a/ARCs/arc-0003.md
+++ b/ARCs/arc-0003.md
@@ -110,7 +110,7 @@ The JSON Metadata schema is as follows:
         },
         "image_mimetype": {
             "type": "string",
-            "description": "The MIME type of the file pointed by the URI image. MUST be one of the MIME type image/* from the IANA media types list: https://www.iana.org/assignments/media-types/media-types.xhtml"
+            "description": "The MIME type of the file pointed by the URI image. MUST be of the form 'image/*'."
         },
         "background_color": {
             "type": "string",
@@ -126,7 +126,7 @@ The JSON Metadata schema is as follows:
         },
         "external_url_mimetype": {
             "type": "string",
-            "description": "The MIME type of the file pointed by the URI image. MUST be one of the MIME type from the IANA media types list: https://www.iana.org/assignments/media-types/media-types.xhtml. SHOULD be text/html"
+            "description": "The MIME type of the file pointed by the URI external_url. It is expected to be 'text/html' in almost all cases."
         },
         "animation_url": {
             "type": "string",
@@ -138,7 +138,7 @@ The JSON Metadata schema is as follows:
         },
         "animation_url_mimetype": {
             "type": "string",
-            "description": "The MIME type of the file pointed by the URI image. MUST be one of the MIME type from the IANA media types list: https://www.iana.org/assignments/media-types/media-types.xhtml. SHOULD be text/html"
+            "description": "The MIME type of the file pointed by the URI animation_url."
         },
         "properties": {
             "type": "object",
@@ -202,7 +202,6 @@ For example, if the field `hello_integrity` is specified, the field `hello` **MU
 Compared to ERC-1155, the metadata JSON schema allows to indicate the MIME type of the files pointed by any URI field.
 This is to allow clients to display appropriately the resource without having to first query it to find out the MIME type.
 Concretly, every URI field `xxx` is allowed to have an optional associated field  `xxx_integrity` that specifies the digest of the file pointed by the URI.
-MIME types **MUST** be one of the MIME type from the IANA media types list: https://www.iana.org/assignments/media-types/media-types.xhtml.
 
 > If MIME types are not properly specified, clients may need to rely on brittle methods to guess the MIME types such as using file extensions.
 

--- a/ARCs/arc-0003.md
+++ b/ARCs/arc-0003.md
@@ -33,13 +33,13 @@ The ASA parameters should follow the following conventions:
     * or `<name>@arc3`, where `<name>` **SHOULD** be closely related to the name in the JSON metadata file:
         * If the resulting asset name can fit the *Asset Name* field, then `<name>` **SHOULD** be equal to the name in the JSON metadata file.
         * If the resulting asset name cannot fit the *Asset Name* field, then `<name>` **SHOULD** be a reasonable shorten version of the name in the JSON metadata file.
-* *URL* (`au`): a URI pointing to a JSON metadata file
-    * The URI **SHOULD** be persistent and allow to download the JSON Metadata file forever.
-    * If the string `{id}` exists in this URI or any other URI, clients **MUST** replace this with the asset ID in decimal form. The rules below applies after such a replacement.
-    * The URI **MUST** follow [RFC-3986](https://www.ietf.org/rfc/rfc3986.txt) and **MUST NOT** contain any whitespace character
-    * **RECOMMENDED** URI schemes (for compatibility and security): *https* and *ipfs*:
+* *Asset URL* (`au`): a URI pointing to a JSON metadata file. This URI as well as any URI in the JSON metadata file:
+    * **SHOULD** be persistent and allow to download the JSON Metadata file forever.
+    * **MAY** contain the string `{id}`. If `{id}` exists in the URI, clients **MUST** replace this with the asset ID in decimal form. The rules below applies after such a replacement.
+    * **MUST** follow [RFC-3986](https://www.ietf.org/rfc/rfc3986.txt) and **MUST NOT** contain any whitespace character
+    * **SHOULD** use one of the following URI schemes (for compatibility and security): *https* and *ipfs*:
         * When the file is stored on IPFS, the `ipfs://...` URI **SHOULD** be used. IPFS Gateway URI (such as `https://ipfs.io/ipfs/...`) **SHOULD NOT** be used.
-    * **NOT RECOMMENDED** URI schemes: *http* (due to security concerns).
+    * **SHOULD NOT** use the following URI scheme: *http* (due to security concerns).
 * *Asset Metadata Hash* (`am`): 
     * If the JSON metadata file specifies extra metadata `e` (property `extra_metadata`), then `am` is defined as:
 
@@ -72,8 +72,10 @@ An ASA is said to be a *fractional non-fungible token* (*fractional NFT*) if and
 ### JSON Metadata File Schema
 
 > The JSON Medata File schema follow the Ethereum Improvement Proposal [ERC-1155 Metadata URI JSON Schema](https://eips.ethereum.org/EIPS/eip-1155) with the following main differences:
-> * Support for integrity properties for any file pointed by any URI field as well as for localized metadata JSON files.
+> * Support for integrity fields for any file pointed by any URI field as well as for localized metadata JSON files.
+> * Support for mimetype fields for any file pointed by any URI field.
 > * Support for extra metadata that is hashed as part of the Asset Metadata Hash (`am`) of the ASA.
+> * Adding the fields `external_url`, `background_color`, `animation_url` used by [OpenSea metadata format](https://docs.opensea.io/docs/metadata-standards).
 
 Similarly to ERC-1155, the URI does support ID substitution. If the URI contains `{id}`, clients **MUST** substitute it by the asset ID in *decimal*.
 
@@ -100,19 +102,51 @@ The JSON Metadata schema is as follows:
         },
         "image": {
             "type": "string",
-            "description": "A URI pointing to a resource with mime type image/* representing the asset to which this token represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive."
+            "description": "A URI pointing to a file with MIME type image/* representing the asset to which this token represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive."
         },
         "image_integrity": {
             "type": "string",
-            "description": "The SHA-256 digest of the file pointed by the URI image. The property value is a single SHA-256 integrity metadata as defined in the W3C subresource integrity specification (https://w3c.github.io/webappsec-subresource-integrity)."
+            "description": "The SHA-256 digest of the file pointed by the URI image. The field value is a single SHA-256 integrity metadata as defined in the W3C subresource integrity specification (https://w3c.github.io/webappsec-subresource-integrity)."
+        },
+        "image_mimetype": {
+            "type": "string",
+            "description": "The MIME type of the file pointed by the URI image. MUST be one of the MIME type image/* from the IANA media types list: https://www.iana.org/assignments/media-types/media-types.xhtml"
+        },
+        "background_color": {
+            "type": "string",
+            "description": "Background color do display the asset. MUST be a six-character hexadecimal without a pre-pended #."
+        },
+        "external_url": {
+            "type": "string",
+            "description": "A URI pointing to an external website presenting the asset."
+        },
+        "external_url_integrity": {
+            "type": "string",
+            "description": "The SHA-256 digest of the file pointed by the URI external_url. The field value is a single SHA-256 integrity metadata as defined in the W3C subresource integrity specification (https://w3c.github.io/webappsec-subresource-integrity)."
+        },
+        "external_url_mimetype": {
+            "type": "string",
+            "description": "The MIME type of the file pointed by the URI image. MUST be one of the MIME type from the IANA media types list: https://www.iana.org/assignments/media-types/media-types.xhtml. SHOULD be text/html"
+        },
+        "animation_url": {
+            "type": "string",
+            "description": "A URI pointing to a multi-media file representing the asset."
+        },
+        "animation_url_integrity": {
+            "type": "string",
+            "description": "The SHA-256 digest of the file pointed by the URI external_url. The field value is a single SHA-256 integrity metadata as defined in the W3C subresource integrity specification (https://w3c.github.io/webappsec-subresource-integrity)."
+        },
+        "animation_url_mimetype": {
+            "type": "string",
+            "description": "The MIME type of the file pointed by the URI image. MUST be one of the MIME type from the IANA media types list: https://www.iana.org/assignments/media-types/media-types.xhtml. SHOULD be text/html"
         },
         "properties": {
             "type": "object",
-            "description": "Arbitrary properties. Values may be strings, numbers, object or arrays."
+            "description": "Arbitrary properties (also called attributes). Values may be strings, numbers, object or arrays."
         },
         "extra_metadata": {
             "type": "string",
-            "description": "Extra metadata in base64. If the property is specified (even if it is an empty string) the asset metadata (am) of the ASA is computed differently than if it is not specified."
+            "description": "Extra metadata in base64. If the field is specified (even if it is an empty string) the asset metadata (am) of the ASA is computed differently than if it is not specified."
         },
         "localization": {
             "type": "object",
@@ -135,7 +169,7 @@ The JSON Metadata schema is as follows:
                     "patternProperties": {
                         ".*": { "type": "string" }
                     },
-                    "description": "The SHA-256 digests of the localized JSON files (except the default one). The property name is the locale. The property value is a single SHA-256 integrity metadata as defined in the W3C subresource integrity specification (https://w3c.github.io/webappsec-subresource-integrity)."
+                    "description": "The SHA-256 digests of the localized JSON files (except the default one). The field name is the locale. The field value is a single SHA-256 integrity metadata as defined in the W3C subresource integrity specification (https://w3c.github.io/webappsec-subresource-integrity)."
                 }
             }
         }
@@ -143,25 +177,39 @@ The JSON Metadata schema is as follows:
 }
 ```
 
-The property `decimals` is **OPTIONAL**. If provided, it **MUST** match the ASA parameter `dt`.
 
-#### Integrity Properties
+The field `decimals` is **OPTIONAL**. If provided, it **MUST** match the ASA parameter `dt`.
+
+URI fields (`image`, `external_url`, `animation_url`) in the JSON metadata file are defined similarly as the Asset URL parameter `au` (see Asset URL above).
+
+
+#### Integrity Fields
 
 Compared to ERC-1155, the metadata JSON schema allows to indicate digests of the files pointed by any URI field.
 This is to ensure the integrity of all the files referenced by the ASA.
-Concretly, every URI property `xxx` is allowed to have an optional associated property  `xxx_integrity` that specifies the digest of the file pointed by the URI.
+Concretly, every URI field `xxx` is allowed to have an optional associated field  `xxx_integrity` that specifies the digest of the file pointed by the URI.
 
 The digests are represented as a single SHA-256 integrity metadata as defined in the [W3C subresource integrity specification](https://w3c.github.io/webappsec-subresource-integrity).
 Details on how to generate those digests can be found on the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) (where `sha384` or `384` are to be replaced by `sha256` and `256` respectively as only SHA-256 is supported by this ARC).
 
-It is **RECOMMENDED** to specify all the `xxx_integrity` properties of all the `xxx` URI properties.
+It is **RECOMMENDED** to specify all the `xxx_integrity` fields of all the `xxx` URI fields, except for `external_url_integrity` when it points to a potentially mutable website.
 
-> Note that the only URI property specified by this schema is `image`. 
-> However, other properties may be used by specific ASAs. 
-> For example, for commonly used properties `external_url`, `animation_url`, or `youtube_url`, digests of the corresponding files may be specified in properties `external_url_integrity`, `animation_url_integrity`, `youtube_url_integrity`.
+Any field with a name ending with `_integrity` **MUST** match a corresponding field containing a URI to a file with a matching digest.
+For example, if the field `hello_integrity` is specified, the field `hello` **MUST** exist and **MUST** be a URI pointing to a file with a digest equal to the digest specified by `hello_integrity`.
 
-Any property with a name ending with `_integrity` **MUST** match a corresponding property containing a URI to a file with a matching digest.
-For example, if the property `hello_integrity` is specified, the property `hello` **MUST** exist and **MUST** be a URI pointing to a file with a digest equal to the digest specified by `hello_integrity`.
+#### MIME Type Files
+
+Compared to ERC-1155, the metadata JSON schema allows to indicate the MIME type of the files pointed by any URI field.
+This is to allow clients to display appropriately the resource without having to first query it to find out the MIME type.
+Concretly, every URI field `xxx` is allowed to have an optional associated field  `xxx_integrity` that specifies the digest of the file pointed by the URI.
+MIME types **MUST** be one of the MIME type from the IANA media types list: https://www.iana.org/assignments/media-types/media-types.xhtml.
+
+> If MIME types are not properly specified, clients may need to rely on brittle methods to guess the MIME types such as using file extensions.
+
+It is **RECOMMENDED** to specify all the `xxx_mimetype` fields of all the `xxx` URI fields, except for `external_url_mimetype` when it points to a website.
+
+Any field with a name ending with `_mimetype` **MUST** match a corresponding field containing a URI to a file with a matching digest.
+For example, if the field `hello_mimetype` is specified, the field `hello` **MUST** exist and **MUST** be a URI pointing to a file with a digest equal to the digest specified by `hello_mimetype`.
 
 #### Localization
 
@@ -176,14 +224,19 @@ It is **RECOMMENDED** that `integrity` contains the digests of all the locales b
 
 ##### Basic Example
 
-An example of an ARC-3 Metadata JSON file follows. The properties array proposes some SUGGESTED formatting for token-specific display properties and metadata.
+An example of an ARC-3 Metadata JSON file for a song follows. The properties array proposes some **SUGGESTED** formatting for token-specific display properties and metadata.
 
 ```json
 {
-	"name": "My Picture",
-	"description": "Lorem ipsum...",
-	"image": "https:\/\/s3.amazonaws.com\/your-bucket\/images\/MyPicture.png",
+	"name": "My Song",
+	"description": "My first and best song!",
+	"image": "https://s3.amazonaws.com/your-bucket/song/cover/mysong.png",
     "image_integrity": "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+    "image_mimetype": "image/png",
+    "external_url": "https://mysongs.com/song/mysong",
+    "animation_url": "https://s3.amazonaws.com/your-bucket/song/preview/mysong.ogg",
+    "animation_url_integrity": "sha256-LwArA6xMdnFF3bvQjwODpeTG/RVn61weQSuoRyynA1I=",
+    "animation_url_mimetype": "audio/ogg",
 	"properties": {
 		"simple_property": "example value",
 		"rich_property": {
@@ -206,10 +259,24 @@ An example of an ARC-3 Metadata JSON file follows. The properties array proposes
 }
 ```
 
+In the example, the `image` field **MAY** be the album cover, while the `animation_url` **MAY** be the full song or may just be a small preview.
+In the latter case, the full song **MAY** be specified by three additional properties inside the `properties` field:
+```json
+{
+    ...
+    "properties": {
+        ...
+        "file_url": "https://s3.amazonaws.com/your-bucket/song/full/mysong.ogg",
+        "file_url_integrity": "sha256-7IGatqxLhUYkruDsEva52Ku43up6774yAmf0k98MXnU=",
+        "file_url_mimetype": "audio/ogg"
+    }
+}
+```
+
 An example of possible ASA parameters would be:
 
-* *Asset Unit*: `mypict` for example
-* *Asset Name*: `My Picture@arc3` or `arc3`
+* *Asset Unit*: `mysong` for example
+* *Asset Name*: `My Song@arc3` or `arc3`
 * *URL*: `ipfs://QmWS1VAdMD353A6SDk9wNyvkT14kyCiZrNDYAad4w1tKqT` or `https://example.com/mypict` or `https://arweave.net/MAVgEMO3qlqe-qHNVs00qgwwbCb6FY2k15vJP3gBLW4`
 * *Metadata Hash*: the 32 bytes of the SHA-256 digest of the above JSON file
 * *Total Number of Units*: 100
@@ -217,17 +284,27 @@ An example of possible ASA parameters would be:
 
 The above parameters define a fractional NFT with 100 shares.
 
-##### Example with Extra Metadata
+The JSON metadata file **MAY** contain the field `decimals: 2`:
+```json
+{
+    ...
+    "decimals": 2
+}
+```
 
-An example of an ARC-3 JSON Metadata file with extra metadata is provided below.
+##### Example with Extra Metadata and `{id}`
+
+An example of an ARC-3 JSON Metadata file with extra metadata and `{id}` is provided below.
 
 ```json
 {
 	"name": "My Picture",
 	"description": "Lorem ipsum...",
-	"image": "https://s3.amazonaws.com/your-bucket/images/MyPicture.png",
+	"image": "https://s3.amazonaws.com/your-bucket/images/{id}.png",
     "image_integrity": "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
-	"extra_metadata": "iHcUslDaL/jEM/oTxqEX++4CS8o3+IZp7/V5Rgchqwc=",
+    "image_mimetype": "image/png",
+    "external_url": "https://mysongs.com/song/{id}",
+	"extra_metadata": "iHcUslDaL/jEM/oTxqEX++4CS8o3+IZp7/V5Rgchqwc="
 }
 ```
 
@@ -313,6 +390,7 @@ The main differences are highlighted below:
 * Asset Name and Asset Unit can be optionally specified in the ASA parameters. This is to allow wallets that are not aware of ARC-3 or that are not able to retrieve the JSON file to still display meaningful information.
 * A digest of the JSON Metadata file is included in the ASA parameters to ensure integrity of this file. This is redundant with the URI when IPFS is used. But this is important to ensure the integrity of the JSON file when IPFS is not used.
 * Similarly, the JSON Metadata schema is changed to allow to specify the SHA-256 digests of the localized versions as well as the SHA-256 digests of any file pointed by a URI property.
+* MIME type fields are added to help clients know how to display the files pointed by URI.
 * When extra metadata are provided, the Asset Metadata Hash parameter is computed using SHA-512/256 with prefix for proper domain separation. SHA-512/256 is the hash function used in Algorand in general (see the list of prefixes in https://github.com/algorand/go-algorand/blob/master/protocol/hash.go). Domain separation is especially important in this case to avoid mixing hash of the metadata JSON file with extra metadata. However, since SHA-512/256 is less common and since not every tool or library allows to compute SHA-512/256, when no extra metadata is specified, SHA-256 is used instead.
 
 Valid JSON metadata files for ERC-1155 are valid JSON metadata files for ARC-3.


### PR DESCRIPTION
This PR is meant to try to provide clearer guidelines
so that clients such as marketplaces can more easily
display NFTs, following some discussions in
#3

Concretely:
1. It adds the fields `external_url`, `animation_url` and
`background_color` used on OpenSea.
2. It clarifies the use of those fields in the example of
a song.
3. It adds `_mimetype` fields that are optional
(for compatiblity with OpenSea) but highly recommended
4. It switched to the term `fields` for JSON fields
to avoid confusion with properties/attributes of the
asset.

Rationale:
1. Keep the fields in the "root" of the JSON metadata
file (as opposed to the properties) limited to
what is required for preview in a markeplace/gallery.
In particular `image` and `animation_url` can be,
for some assets, just preview, as opposed to the
full asset.
Remark for example that the field `image` restricts
a lot the maximum dimension of the image, so that
high-quality photography could not fit this field.
2. Full media files (e.g., full songs, high-quality photo),
licenses, and other such properties
are moved to properties and are left out of scope of this
proposal. Future proposals may try to standardize these
properties, although a global cross-chain standard
would be even more beneficial.

Points of dicussion:
1. Should MIME types be mandatory? This would break
backward compatibility with ERC-1155 and make most
existing NFT metadata invalid in the context of ARC-3.
The proposed solution is that clients may decide to
guess the MIME type from the extension of the file
(or from a HEAD query) when not available. The former
is what OpenSea seems to be doing.
This is much more brittle, hence the strong recommendation
for specifying MIME types.
2. Should URI properties (i.e., inside the `properties` field
and not at the root), should also follow the same rules.
In particular, should we allow `{id}` there? It may actually
be an issue as marketplace may not be able to recognize
which fields are URI.
3. Is this proposal too restrictive and should we finalize
ARC-0003 without it completely, sticking to being close
to ERC-1155 (with integrity fields and extra metadata though)
(In case this proposal is rejected, we may want to keep
the renaming of properties into fields.)