### PR TITLE
ARC-0001: Renaming signTxn to signTxns

### DIFF
--- a/ARCs/arc-0001.md
+++ b/ARCs/arc-0001.md
@@ -80,7 +80,7 @@ Each transaction is represented by a `WalletTransaction` object. The only requir
 
 A wallet transaction signing function `signTxns` is defined by the following interface:
 ```typescript
-export type SignTxnFunction = (
+export type SignTxnsFunction = (
    txns: WalletTransaction[],
    opts?: SignTxnOpts
 )

--- a/ARCs/arc-0001.md
+++ b/ARCs/arc-0001.md
@@ -34,7 +34,7 @@ At a high-level the API allows to sign:
 * A valid group of transaction (aka atomic transfers).
 * (**OPTIONAL**) A list of groups of transactions.
 
-Signatures are requested by calling a function `signTxn(txns)` on a list `txns` of transactions. The dApp may also provide an optional parameter `opts`. 
+Signatures are requested by calling a function `signTxns(txns)` on a list `txns` of transactions. The dApp may also provide an optional parameter `opts`. 
 
 Each transaction is represented by a `WalletTransaction` object. The only required field of a `WalletTransaction` is `txn`, a base64 encoding of the canonical msgpack encoding of the unsigned transaction. There are three main use cases:
 
@@ -76,9 +76,9 @@ Each transaction is represented by a `WalletTransaction` object. The only requir
 
 > Interfaces are defined in TypeScript. All the objects that are defined are valid JSON objects.
 
-#### Interface `signTxn`
+#### Interface `signTxns`
 
-A wallet transaction signing function `signTxn` is defined by the following interface:
+A wallet transaction signing function `signTxns` is defined by the following interface:
 ```typescript
 export type SignTxnFunction = (
    txns: WalletTransaction[],
@@ -90,7 +90,7 @@ where:
 * `txns` is a non-empty list of `WalletTransaction` objects (defined below).
 * `opts` is an optional parameter object `SignTxnOpts` (defined below).
 
-In case of error, the wallet (i.e., the `signTxn` function in this document) **MUST** throw an error object `SignTxnError` defined below.
+In case of error, the wallet (i.e., the `signTxns` function in this document) **MUST** throw an error object `SignTxnError` defined below.
 
 #### Interface `AlgorandAddress`
 
@@ -174,7 +174,7 @@ export interface WalletTransaction {
 
 #### Interface `SignTxnOpts`
 
-A `SignTxnOps` specifies optional parameters of the `signTxn` function:
+A `SignTxnOps` specifies optional parameters of the `signTxns` function:
 ```typescript
 export type SignTxnOpts = {
    /**
@@ -186,7 +186,7 @@ export type SignTxnOpts = {
 
 #### Error Interface `SignTxnError`
 
-In case of error, the `signTxn` function **MUST** return a `SignTxnError` object
+In case of error, the `signTxns` function **MUST** return a `SignTxnError` object
 ```typescript
 interface SignTxnError extends Error {
   code: number;
@@ -228,7 +228,7 @@ Wallet-specific extensions **MUST** be designed such that a wallet not understan
 
 ### Semantic and Security Requirements
 
-The call `signTxn(txns, opts)` **MUST** either throws an error or return an array `ret` of the same length of the `txns` array:
+The call `signTxns(txns, opts)` **MUST** either throws an error or return an array `ret` of the same length of the `txns` array:
 
 1. If `txns[i].signers` is an empty array, the transaction `txns[i]` **MUST** not be signed and `ret[i]` **MUST** be set to `null`.
 2. Otherwise, the wallet **MUST** sign the transaction `txns[i]` and `ret[i]` **MUST** be set to the base64 encoding of the canonical msgpack encoding of the `SignedTxn` corresponding object, as defined in the [Algorand specs](https://github.com/algorandfoundation/specs). For Algorand version 2.5.5, see the [authorization and signatures Section](https://github.com/algorandfoundation/specs/blob/d050b3cade6d5c664df8bd729bf219f179812595/dev/ledger.md#authorization-and-signatures) of the specs or the [Go structure](https://github.com/algorand/go-algorand/blob/304815d00b9512cf9f91dbb987fead35894676f4/data/transactions/signedtxn.go#L31).
@@ -395,7 +395,7 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 
 ### Sign a Group of Two Transactions
 
-Here is an example in node.js how to use the wallet interface to sign a group of two transactions and send them to the network. The function `signTxn` is assumed to be a method of `algorandWallet`.
+Here is an example in node.js how to use the wallet interface to sign a group of two transactions and send them to the network. The function `signTxns` is assumed to be a method of `algorandWallet`.
 
 > Note: We will be working with the algosdk development to add two helper functions to facilitate the use of the wallet. Current idea is to add:
 `Transaction.toBase64` that does the same as `Transaction.toByte` except it outputs a base64 string
@@ -438,7 +438,7 @@ const txn1B64 = Buffer.from(txn1.toByte()).toString("base64");
 const txn2B64 = Buffer.from(txn2.toByte()).toString("base64");
 
 (async () => {
-   const signedTxs = await algorandWallet.signTxn([
+   const signedTxs = await algorandWallet.signTxns([
        {txn: txn1B64},
        {txn: txn2B64, signers: []}
    ]);


### PR DESCRIPTION
Following comment
https://github.com/algorandfoundation/ARCs/issues/1#issuecomment-895374290
from @DanBurton

This PR is to be dicussed.
`signTxns` is indeed more logical.

`signTxn` can still exist and be mapped to `signTxns` for backward
compatibility.

So I don't think this should create too many issues
but please raise your voice if it does.