### PR TITLE
Support of #arc3 in URL, MIME, CORS

### DIFF
--- a/ARCs/arc-0003.md
+++ b/ARCs/arc-0003.md
@@ -1,7 +1,7 @@
 ---
 arc: 3
 title: Algorand Standard Asset Parameters Conventions for Fungible and Non-Fungible Tokens
-status: Last Call
+status: Final
 ---
 
 # Algorand Standard Asset Parameters Conventions for Fungible and Non-Fungible Tokens
@@ -295,14 +295,22 @@ In the latter case, the full song **MAY** be specified by three additional prope
 An example of possible ASA parameters would be:
 
 * *Asset Unit*: `mysong` for example
-* *Asset Name*: `My Song@arc3` or `arc3`
-* *Asset URL*: `ipfs://QmWS1VAdMD353A6SDk9wNyvkT14kyCiZrNDYAad4w1tKqT` or `https://example.com/mypict` or `https://arweave.net/MAVgEMO3qlqe-qHNVs00qgwwbCb6FY2k15vJP3gBLW4`
+* *Asset Name*: `My Song`
+* *Asset URL*: `https://example.com/mypict#arc3` or `https://arweave.net/MAVgEMO3qlqe-qHNVs00qgwwbCb6FY2k15vJP3gBLW4#arc3`
 * *Metadata Hash*: the 32 bytes of the SHA-256 digest of the above JSON file
 * *Total Number of Units*: 100
 * *Number of Digits after the Decimal Point*: 2
 
-The above parameters define a fractional NFT with 100 shares.
+> IPFS urls of the form `ipfs://QmWS1VAdMD353A6SDk9wNyvkT14kyCiZrNDYAad4w1tKqT#arc3` may be used too but may cause issue with clients that do not support ARC-3 and that do not handle fragments in IPFS URLs.
 
+Example of alternative versions for *Asset Name* and *Asset URL*:
+
+* *Asset Name*: `My Song@arc3` or `arc3`
+* *Asset URL*: `ipfs://QmWS1VAdMD353A6SDk9wNyvkT14kyCiZrNDYAad4w1tKqT` or `https://example.com/mypict` or `https://arweave.net/MAVgEMO3qlqe-qHNVs00qgwwbCb6FY2k15vJP3gBLW4`
+
+> These alternative versions are less recommended as they make the asset name harder to read for clients that do not support ARC-3.
+
+The above parameters define a fractional NFT with 100 shares.
 The JSON Metadata file **MAY** contain the field `decimals: 2`:
 ```json
 {


### PR DESCRIPTION
This PR applies the proposed changes in
https://github.com/algorandfoundation/ARCs/issues/3#issuecomment-930630064

as well as in:
https://github.com/algorandfoundation/ARCs/issues/3#issuecomment-926259384
https://github.com/algorandfoundation/ARCs/issues/3#issuecomment-926590736
(for MIME types)

More precisely:
* allow to use `#arc3` in URL
* explicitly indicate that MIME types should not be relied upon from a
security point of view
* make MIME types STRONGLY RECOMMENDED