### PR TITLE
Adding ARCs 0004 to 0011 and updating ARC 0001

### DIFF
--- a/ARCs/arc-0001.md
+++ b/ARCs/arc-0001.md
@@ -82,15 +82,16 @@ A wallet transaction signing function `signTxns` is defined by the following int
 ```typescript
 export type SignTxnsFunction = (
    txns: WalletTransaction[],
-   opts?: SignTxnOpts
+   opts?: SignTxnsOpts
 )
    => Promise<(string | null)[]>;
 ```
 where:
 * `txns` is a non-empty list of `WalletTransaction` objects (defined below).
-* `opts` is an optional parameter object `SignTxnOpts` (defined below).
+* `opts` is an optional parameter object `SignTxnsOpts` (defined below).
 
-In case of error, the wallet (i.e., the `signTxns` function in this document) **MUST** throw an error object `SignTxnError` defined below.
+In case of error, the wallet (i.e., the `signTxns` function in this document) **MUST** reject the promise with an error object `SignTxnsError` defined below.
+This ARC uses interchangeably the terms "throw an error" and "reject a promise with an error".
 
 #### Interface `AlgorandAddress`
 
@@ -178,11 +179,11 @@ export interface WalletTransaction {
 ```
 
 
-#### Interface `SignTxnOpts`
+#### Interface `SignTxnsOpts`
 
-A `SignTxnOps` specifies optional parameters of the `signTxns` function:
+A `SignTxnsOps` specifies optional parameters of the `signTxns` function:
 ```typescript
-export type SignTxnOpts = {
+export type SignTxnsOpts = {
    /**
     * Optional message explaining the reason of the group of transactions
     */
@@ -190,11 +191,11 @@ export type SignTxnOpts = {
 }
 ```
 
-#### Error Interface `SignTxnError`
+#### Error Interface `SignTxnsError`
 
-In case of error, the `signTxns` function **MUST** return a `SignTxnError` object
+In case of error, the `signTxns` function **MUST** return a `SignTxnsError` object
 ```typescript
-interface SignTxnError extends Error {
+interface SignTxnsError extends Error {
   code: number;
   data?: any;
 }
@@ -220,11 +221,12 @@ where:
 | 4100 | Unauthorized |  The requested operation and/or account has not been authorized by the user. | 
 | 4200 | Unsupported Operation | The wallet does not support the requested operation. |
 | 4201 | Too Many Transactions | The wallet does not support signing that many transactions at a time. |
+| 4202 | Unintialized Wallet | The wallet was not initialized properly beforehand. |
 | 4300 | Invalid Input | The input provided is invalid. |
 
 ### Wallet-specific extensions
 
-Wallets **MAY** use specific extension fields in `WalletTransaction` and in `SignTxnOpts`. These fields must start with: `_walletName`, where `walletName` is the name of the wallet. Wallet designers **SHOULD** ensure that their wallet name is not already used.
+Wallets **MAY** use specific extension fields in `WalletTransaction` and in `SignTxnsOpts`. These fields must start with: `_walletName`, where `walletName` is the name of the wallet. Wallet designers **SHOULD** ensure that their wallet name is not already used.
 
 > Example of a wallet-specific fields in `opts` (for the wallet `theBestAlgorandWallet`): `_theBestAlgorandWalletIcon` for displaying an icon related to the transactions.
 
@@ -252,8 +254,6 @@ All the field names below are the ones in the [Go `SignedTxn` structure](https:/
 **Rejecting** means throwing a `4300` error.
 
 Strong warning / warning / weak warning / informational messages are different level of alerts. Strong warnings **MUST** be displayed in such a way that the user cannot miss the importance of them.
-
-
 
 #### Semantic of `WalletTransaction`
 
@@ -300,7 +300,7 @@ However, in all these cases, the resulting `SignedTxn` **MUST** be such that it 
 
 In particular, if a multisig is used, the numbers of subsigs provided must be at least equal to the multisig threshold. This is different from the case where `msig` is provided, where the wallet **MAY** provide fewer subsigs than the threshold.
 
-#### Semantic of `SignTxnOpts`
+#### Semantic of `SignTxnsOpts`
 
 * `message` obeys the rules as `WalletTransaction.message` except it is a message common to all transactions.
 
@@ -322,7 +322,7 @@ If there is any unexpected field at any level (both in the transaction itself or
 The wallet should support the following two use cases:
 
 1. (**REQUIRED**) `txns` is a non-empty array of transactions that belong to the same group of transactions. In other words, either `txns` is an array of a single transaction with a zero group ID (`txn.Group`), or `txns` is an array of more than one transactions with the *same* non-zero group ID. The wallet **MUST** reject if the transactions do not match their group ID. (The dApp must provide the transactions in the order defined by the group ID.)
-2. (**OPTIONAL**) `txns` is a concatenation of `txns` arrays of type 1 or 2:
+2. (**OPTIONAL**) `txns` is a concatenation of `txns` arrays of transactions of type 1:
    * All transactions with the *same* non-zero group ID must be consecutive and must match their group ID. The wallet **MUST** reject if the above is not satisfied. 
    * The wallet UI **MUST** be designed so that it is clear to the user when transactions are grouped (aka form an atomic transfers) and when they are not. It **SHOULD** provide very clear explanations that are understandable by beginner users, so that they cannot easily be tricked to sign what they believe is an atomic exchange while it is in actuality a one-sided payment.
 
@@ -367,7 +367,7 @@ The wallet **MUST** check that the genesis hash (field `txn.GenesisHash`) and th
 In general, the UI **MUST** ensure that the user cannot be confused by the dApp to perform dangerous operations. In particular, the wallet **MUST** make clear to the user what is part of the wallet UI from what is part of what the dApp provided.
 
 Special care **MUST** be taken of when:
-* Displaying the `message` field of `WalletTransaction` and of `SignTxnOpts`.
+* Displaying the `message` field of `WalletTransaction` and of `SignTxnsOpts`.
 * Displaying any arbitrary field of transactions including note field (`txn.Note`), genesis ID (`txn.genesisID`), asset configuration fields (`txn.AssetName`, `txn.UnitName`, `txn.URL`, ...)
 * Displaying message hidden in fields that are expected to be base32/base64-strings or addresses. Using a different font for those fields **MAY** be an option to prevent such confusion.
 

--- a/ARCs/arc-0005.md
+++ b/ARCs/arc-0005.md
@@ -16,16 +16,23 @@ An API for a function used to sign a list of transactions on the Algorand blockc
 
 ## Abstract
 
-[ARC-0001](ARC-0001.md) defines a standard for signing transactions with security in mind. This proposal is a strict subset of ARC-0001 that outlines only the minimum functionality required in order to be useable.
+[ARC-0001](arc-0001.md) defines a standard for signing transactions with security in mind. This proposal is a strict subset of ARC-0001 that outlines only the minimum functionality required in order to be useable.
 
 Wallets that conform to ARC-0001 already conform to this API.
 
+Wallets conforming to ARC-0005 but not ARC-0001 **MUST** only be used for testing purposes and **MUST NOT** used on MainNet.
+This is because this ARC-0005 does not provide the same security guarantees as ARC-0001 to protect properly wallet users.
+
 ## Specification
+
+The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in [RFC-2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+> Comments like this are non-normative.
 
 ### Interface `SignTxnFunction`
 
 ```ts
-export type SignTxnFunction = (
+export type SignTxnsFunction = (
    txns: WalletTransaction[],
    opts?: any,
 )
@@ -33,8 +40,7 @@ export type SignTxnFunction = (
 ```
 
 A `SignTxnFunction`:
-
-* MAY expect `txns` to be in the correct format as specified by `WalletTransaction`.
+* expects `txns` to be in the correct format as specified by `WalletTransaction`.
 
 ### Interface `WalletTransaction`
 
@@ -49,8 +55,16 @@ export interface WalletTransaction {
 
 ### Semantic requirements
 
-* The call `signTxn(txns, opts)` MUST either throw an error or return an array `ret` of the same length as the `txns` array.
-* Each element of `ret` MUST be the base64 encoding of the canonical msgpack encoding of the `SignedTxn` corresponding object, as defined in the [Algorand specs](https://github.com/algorandfoundation/specs).
+* The call `signTxn(txns, opts)` **MUST** either throw an error or return an array `ret` of the same length as the `txns` array.
+* Each element of `ret` **MUST** be the base64 encoding of the canonical msgpack encoding of the `SignedTxn` corresponding object, as defined in the [Algorand specs](https://github.com/algorandfoundation/specs).
+
+This ARC uses interchangeably the terms "throw an error" and "reject a promise with an error".
+
+`signTxn` **SHOULD** follow the error standard specified in [ARC-0001](arc-0001.md).
+
+### UI requirements
+
+Wallets satisfying this ARC but not [ARC-0001](arc-0001.md) **MUST** clearly display a warning to the user that they **MUST** not be used with real funds on MainNet.
 
 ## Rationale
 
@@ -59,7 +73,7 @@ This simplified version of ARC-0001 exists for two main reasons:
 1. To outline the minimum amount of functionality needed in order to be useful.
 2. To serve as a stepping stone towards full ARC-0001 compatibility.
 
-While users would be wise to select a wallet that fully adheres to ARC-0001, this simplified API sets a lower bar and acts as a signpost for which wallets can even be used at all.
+While this ARC **MUST** not be used by users with real funds on MainNet for security reasons, this simplified API sets a lower bar and acts as a signpost for which wallets can even be used at all.
 
 ## Copyright
 

--- a/ARCs/arc-0006.md
+++ b/ARCs/arc-0006.md
@@ -15,76 +15,138 @@ An API for a function used to discover the addresses a wallet user is willing to
 
 ## Abstract
 
-A function, `enable`, which allows the discovery of accounts. This document requires nothing else, but further semantic meaning is prescribed to `enable` in [ARC-0010](ARC-0010.md) which builds off of this one and a few others.
+A function, `enable`, which allows the discovery of accounts. 
+This document requires nothing else, but further semantic meaning is prescribed to `enable` in [ARC-0010](ARC-0010.md) which builds off of this one and a few others.
+The caller of this function is usually a dApp.
 
 ## Specification
+
+The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in [RFC-2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+> Comments like this are non-normative.
 
 ### Interface `EnableFunction`
 
 ```ts
+export type AlgorandAddress = string;
+export type GenesisHash = string;
+
 export type EnableFunction = (
   opts?: EnableOpts
 ) => Promise<EnableResult>;
 
 export interface EnableOpts = {
-  network?: string;    // NetworkIdentifier
-  accounts?: string[]; // AlgorandAddress[]
+  genesisID?: string;
+  genesisHash?: GenesisHash;
+  accounts?: AlgorandAddress[];
 }
 
 export interface EnableResult = {
-  network: string;    // NetworkIdentifier
-  accounts: string[]; // AlgorandAddress[]
+  genesisID: string;
+  genesisHash: GenesisHash;
+  accounts: AlgorandAddress[];
+}
+
+export interface EnableError extends Error {
+  code: number;
+  data?: any;
 }
 ```
 
-An `EnableFunction` with input argument `opts:EnableOpts` and return value `ret:EnableResult`:
+An `EnableFunction` with optional input argument `opts:EnableOpts` **MUST** return a value `ret:EnableResult` or **MUST** throw an exception object of type `EnableError`.
 
-* MAY expect `opts.network` to be in the correct format as specified by `NetworkIdentifier`.
-* MAY expect `opts.accounts` to be in the correct format as specified by `AlgorandAddress`.
-* MUST return `network` in the format of `NetworkIdentifier`
-* MUST return `accounts` in the format of an array of `AlgorandAddress`
+### String specification: `GenesisID` and `GenesisHash`
 
-### String specification: `NetworkIdentifier`
+A `GenesisID` is an ascii string 
 
-A `NetworkIdentifier` string must be in the format `"${network}-${id}"`, such as `"testnet-v1.0"` and `"mainnet-v1.0"`.
+A `GenesisHash` is base64 string representing a 32-byte genesis hash.
 
 ### String specification: `AlgorandAddress`
 
-Quoting [ARC-0001](ARC-0001.md):
+Defined as in [ARC-0001](ARC-0001.md):
 
 > An Algorand address is represented by a 58-character base32 string. It includes includes the checksum.
 
+### Error Standards
+
+`EnableError` follows the same rules as `SignTxnsError` from [ARC-0001](ARC-0001.md) and uses the same status error codes.
+
+
 ### Semantic requirements
 
-Regarding a call to `enable(opts)` or `enable()` (where `opts` is `undefined`), with potential promised return value `ret`:
+This ARC uses interchangeably the terms "throw an error" and "reject a promise with an error".
 
-When `network` is specified in `opts`:
+#### First call to `enable`
 
-* The call `enable(opts)` MUST either throw an error or return an object `ret` where `ret.network` is identical to `opts.network`.
-* The user SHOULD be prompted for permission to acknowledge control of accounts on that specific network.
+Regarding a first call by a caller to `enable(opts)` or `enable()` (where `opts` is `undefined`), with potential promised return value `ret`:
 
-When `network` is not specified in `opts`:
+When `genesisID` and/or `genesisHash` is specified in `opts`:
 
-* The user SHOULD be prompted to select the network they wish to use.
-* The call `enable(opts)` MUST either throw an error or return an object `ret` where `ret.network` SHOULD represent the user's selection of network and MUST adhere to the `NetworkIdentifier` string format.
-* The function MAY throw an error if it does not support user selection of network.
+* The call `enable(opts)` **MUST** either throw an error or return an object `ret` where `ret.genesisID` and `ret.genesisHash` match `opts.genesisID` and `opts.genesisHash` (i.e., `ret.genesisID` is identical to `opts.genesisID` if `opts.genesisID` is specified, and `ret.genesisHash` is idential to `opts.genesisHash` if `opts.genesisHash` is sepcified).
+* The user **SHOULD** be prompted for permission to acknowledge control of accounts on that specific network (defined by `ret.genesisID` and `ret.genesisHash`).
+* In the case only `opts.genesisID` is provided, several networks may match this ID and the user **SHOULD** be prompted to select the network they wish to use.
+
+When neither `genesisID` nor `genesisHash` is specified in `opts`:
+
+* The user **SHOULD** be prompted to select the network they wish to use.
+* The call `enable(opts)` **MUST** either throw an error or return an object `ret` where `ret.genesisID` and `ret.genesisHash` **SHOULD** represent the user's selection of network.
+* The function **MAY** throw an error if it does not support user selection of network.
 
 When `accounts` is specified in `opts`:
 
-* The call `enable(opts)` MUST either throw an error or return an object `ret` where `ret.accounts` is an array that starts with all the same elements as `opts.accounts`, in the same order.
-* When `accounts` are specified in the `opts`, the user SHOULD be prompted for permission to acknowledge their control of the specified accounts. The wallet MAY allow the user to provide more accounts than those listed.
+* The call `enable(opts)` **MUST** either throw an error or return an object `ret` where `ret.accounts` is an array that starts with all the same elements as `opts.accounts`, in the same order.
+* The user **SHOULD** be prompted for permission to acknowledge their control of the specified accounts. The wallet **MAY** allow the user to provide more accounts than those listed.
 
 When `accounts` is not specified in `opts`:
 
-* The user SHOULD be prompted to select the accounts they wish to reveal on the selected network.
-* The call `enable(opts)` MUST either throw an error or return an object `ret` where `ret.accounts` is a non-empty array.
-* The caller MAY assume that `ret.accounts[0]` is the user's "currently-selected" or "default" account, for DApps that only require access to one account.
+* The user **SHOULD** be prompted to select the accounts they wish to reveal on the selected network.
+* The call `enable(opts)` **MUST** either throw an error or return an object `ret` where `ret.accounts` is a empty or non-empty array.
+* If `ret.accounts` is not empty, the caller **MAY** assume that `ret.accounts[0]` is the user's "currently-selected" or "default" account, for DApps that only require access to one account.
+
+> Empty `ret.accounts` array are used to allow a DApp to get access to an Algorand node but not to signing capabilities.
+
+#### Network
+
+In addition to the above rules, in all cases, if `ret.genesisID` is one of the official network `mainnet-v1.0`, `testnet-v1.0`, or `betanet-v1.0`, `ret.genesisHash` **MUST** match the genesis hash of those networks
+
+| Genesis ID | Genesis Hash |
+| ---------- | ------------ |
+| `mainnet-v1.0` | `wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=` |
+| `testnet-v1.0` | `SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=` |
+| `betanet-v1.0` | `mFgazF+2uRS1tMiL9dsj01hJGySEmPN28B/TjjvpVW0=` |
+
+When using a genesis ID that is not one of the above, the caller **SHOULD** always provide a `genesisHash`.
+This is because a `genesisID` does not uniquely define a network in that case.
+If a caller does not provide a `genesisHash`, multiple calls to `enable` may return a different network with the same `genesisID` but a different `genesisHash`.
+
+#### Identification of the caller
+
+The `enable` function **MAY** remember the choices of the user made by a specific caller and use them everytime the same caller calls the function.
+The function **MUST** ensure that the caller can be securely identified.
+In particular, by default, the function **MUST NOT** allow webapps on the http protocol to call it, as such webapps can easily be modified by a man-in-the-middle attacker.
+In the case of callers that are https websites, the caller **SHOULD** be identified by its fully qualified domain name.
+
+The function **MAY** offer the user some "developer mode" or "advanced" options to allow calls from insecure dApps.
+In that case, the fact that the caller is insecure and/or the fact that the wallet in in "developer mode" **MUST** be clearly displayed by the wallet.
+
+#### Multiple calls to `enable`
+
+The same caller **MAY** call multiple time the `enable` function.
+When the caller is a dApp, every time a dApp is refreshed, it actually **SHOULD** call the `enable()` function.
+
+The `enable` function **MAY NOT** return the same value every time it is called, even when called with the exact same argument `opts`.
+The caller **MUST NOT** assume that the `enable` function will return always the same value and **MUST** properly handle changes of available accounts and/or changes of network.
+
+For example, a user may want to change network or accounts for a dApp.
+That is why, upon refresh, the dApp **SHOULD** automatically switch network and perform all required changes.
+Examples of required changes include but are not limited to change of the list of accounts, change of statuses of the account (e.g., opted in or not), change of the balances of the accounts. 
 
 ## Rationale
 
-This API puts power in the user's hands to choose a preferred network and account to use when interacting with a DApp.
+This API puts power in the user's hands to choose a preferred network and account to use when interacting with a dApp.
 
-It also allows DApp developers to suggest a specific network, or specific accounts, as appropriate. The user still maintains the ability to reject the DApp's suggestions, which corresponds to rejecting the promise returned by `enable()`.
+It also allows dApp developers to suggest a specific network, or specific accounts, as appropriate. 
+The user still maintains the ability to reject the dApp's suggestions, which corresponds to rejecting the promise returned by `enable()`.
 
 ## Copyright
 

--- a/ARCs/arc-0007.md
+++ b/ARCs/arc-0007.md
@@ -19,41 +19,78 @@ A function, `postTxns`, which accepts an array of `SignedTransaction`s, and post
 
 ## Specification
 
+The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in [RFC-2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+> Comments like this are non-normative.
+
+This ARC uses interchangeably the terms "throw an error" and "reject a promise with an error".
+
 ### Interface `PostTxnsFunction`
 
 ```ts
+export type TxnId = string;
+export type SignedTxnStr = string;
+
 export type PostTxnsFunction = (
-  stxns: string[], // SignedTxnStr
+  stxns: SignedTxnStr[],
 ) => Promise<PostTxnsResult>;
 
 export interface PostTxnsResult {
-  txId: string; // TxId
+  txnIds: TxnId[];
+}
+
+export interface PostTxnsError extends Error {
+  code: number;
+  data?: any;
+  successTxnIds: (TxnId | null)[];
 }
 ```
 
 A `PostTxnsFunction` with input argument `stxns:string[]` and promised return value `ret:PostTxnsResult`:
+* expects `stxns` to be in the correct string format as specified by `SignedTxnStr`.
+* **MUST**, if successful, return an object `ret` such that `ret.txId` is in the correct string format as specified by `TxId`.
 
-* MAY expect `stxns` to be in the correct string format as specified by `SignedTxnStr`.
-* MUST, if successful, return an object `ret` such that `ret.txId` is in the correct string format as specified by `TransactionId`
+> The use of `txId` instead of `txnId` is to follow the standard name for the transaction ID.
 
 ### String specification: `SignedTxnStr`
 
-Quoting ARC-0001:
+Defined as in [ARC-0001](ARC-0001.md):
 
 > [`SignedTxnStr` is] the base64 encoding of the canonical msgpack encoding of the `SignedTxn` corresponding object, as defined in the [Algorand specs](https://github.com/algorandfoundation/specs).
 
-### String specification: `TxId`
+### String specification: `TxnId`
 
-A `TxId` is a 52-character base32 string.
+A `TxnId` is a 52-character base32 string (without padding) corresponding to a 32-byte string;
+
+### Error standard
+
+`PostTxnsError` follows the same rules as `SignTxnsError` from [ARC-0001](ARC-0001.md) and uses the same status codes as well as the following status codes:
+
+
+| Status Code | Name | Description |
+| ----------- | ---- | ----------- |
+| 4400 | Failure Sending Some Transactions | Some transactions were not sent properly. |
 
 ### Semantic requirements
 
 Regarding a call to `postTxns(stxns)` with promised return value `ret`:
 
-* `postTxns` MAY assume that `stxns` are in the correct format as specified by `SignedTxnStr`.
-* `postTxns` MUST attempt to post all transactions together.
-* If successful, `postTxns` MUST resolve the returned promise with the `TxId` received from the network. (This SHOULD be the transaction ID for the first transaction in the group.)
-* If unsuccessful, `postTxns` MUST reject the promise with an error. The error SHOULD describe what went wrong in as much detail as possible.
+* `postTxns` **MAY** assume that `stxns` is an array of valid `SignedTxnStr` strings that represent correctly signed transactions such that:
+  * Either all transaction belong to the same group of transactions and are in the correct order. In other words, either `stxns` is an array of a single transaction with a zero group ID (`txn.Group`), or `stxns` is an array of more than one transactions with the *same* non-zero group ID. The function **MUST** reject if the transactions do not match their group ID. (The caller must provide the transactions in the order defined by the group ID.)
+  * Or `stxns` is a concatenation of arrays satisfying the above.
+* `postTxns` **MUST** attempt to post all transactions together.  With the `algod` v2 API, this implies splitting the transactins into groups and making an API call per transaction group. `postTxns` **SHOULD NOT** wait after each transaction group but post all of them without pause in-between.
+* `postTxns` **MAY** ask the user whether they are approve posting those transactions.
+  > A dApp can always post transactions itself without the help of `postTxns` when a public network is used.
+  > However, when a private network is used, a dApp may need `postTxns`, and in this case, asking the user's approval can make sense.
+  > Another such use case is when the user uses a specific trusted node that has some legal restrictions.
+* `postTxns` **MUST** wait for confirmation that the transactions are finalized.
+  > TODO: Decide whether to add an optional flag to not wait for that.
+* If successful, `postTxns` **MUST** resolve the returned promise with the list of transaction IDs `txnIds` of the posted transactions `stxn`.
+* If unsuccessful, `postTxns` **MUST** reject the promise with an error `err` of type `PostTxnsError` such that:
+  * `err.code=4400` if there was a failure sending the transactions or a code as specified in [ARC-0001](ARC-0001.md) if the user or function disallowed posting the transactions.
+  * `err.message` **SHOULD** describe what went wrong in as much detail as possible.
+  * `err.successTxnIds` **MUST** be an array such that `err.successTxnId[i]` is the transaction ID of `stxns[i]` if `stxns[i]` was succesfully committed to the blockchain, and `null` otherwise.
+
 
 ## Rationale
 

--- a/ARCs/arc-0008.md
+++ b/ARCs/arc-0008.md
@@ -33,6 +33,8 @@ export type SignAndPostTxnsFunction = (
 * `WalletTransaction` is as specified by [ARC-0005](arc-0005.md).
 * `PostTxnsResult` is as specified by [ARC-0007](arc-0007.md).
 
+Errors are handled exactly as specified by [ARC-0001](arc-0001.md) / [ARC-0005](arc-0005.md) and [ARC-0007](arc-0007.md)
+
 ## Rationale
 
 Allows the user to be sure that what they are signing is in fact all that is being sent. Doesn't necessarily grant the DApp direct access to the signed txns, though they are posted to the network, so they should not be considered private.

--- a/ARCs/arc-0009.md
+++ b/ARCs/arc-0009.md
@@ -16,31 +16,41 @@ An API for accessing Algod and Indexer through a user's preferred connection.
 
 ## Abstract
 
-Functions `getAlgodv2` and `getIndexer` which return the corresponding algosdk objects.
+Functions `getAlgodv2Client` and `getIndexerClient` which return a `BaseHTTPClient` that can be used to construct an `Algodv2Client` and an `IndexerClient` respectively (from the [JS SDK](https://github.com/algorand/js-algorand-sdk/blob/develop/src/main.ts));
 
 ## Specification
 
-### Interface `GetAlgodv2Function`
+### Interface `GetAlgodv2ClientFunction`
 
 ```ts
-type GetAlgodv2Function = () => Promise<Algodv2>
+type GetAlgodv2ClientFunction = () => Promise<BaseHTTPClient>
 ```
 
-Returns a promised `Algodv2`, where `Algodv2` is an interface matching the class `algosdk.Algodv2`.
+Returns a promised `BaseHTTPClient` that can be used to then build an `Algodv2Client`, where `BaseHTTPClient` is an interface matching the interface `algosdk.BaseHTTPClient` from the [JS SDK](https://github.com/algorand/js-algorand-sdk/blob/develop/src/main.ts).
 
-### Interface `GetIndexerFunction`
+### Interface `GetIndexerClientFunction`
 
 ```ts
-type GetIndexerFunction = () => Promise<Indexer>
+type GetIndexerClientFunction = () => Promise<BaseHTTPClient>
 ```
 
-Returns a promised `Indexer`, where `Indexer` is an interface matching the class `algosdk.Indexer`.
+Returns a promised `BaseHTTPClient` that can be used to then build an `Indexer`, where `BaseHTTPClient` is an interface matching the interface `algosdk.BaseHTTPClient` from the [JS SDK](https://github.com/algorand/js-algorand-sdk/blob/develop/src/main.ts).
+
+### Security considerations
+
+The returned `BaseHTTPClient` **SHOULD** filter the queries made to prevent potential attacks and reject (i.e., throw an exception) if this is not satisfied.
+A non-exhaustive list of checks is provided below:
+* Check that the relative PATH does not contain `..`.
+* Check that the only provided headers are the ones used by the SDK (when this ARC was written: `accept` and `content-type`) and their values are the ones provided by the SDK.
+
+`BaseHTTPClient` **MAY** impose rate limits.
+
+For higher security, `BaseHTTPClient` **MAY** also check the queries with regards to the OpenAPI specification of the node and the indexer.
 
 ## Rationale
 
-Nontrivial DApps often require the ability to query the network for activity. Algorand DApps written without regard to wallets are likely written using `Algodv2` and `Indexer` from `algosdk`. This document is a very blunt approach to exposing identical querying functionality through a wallet, making it easy for JavaScript DApp authors to port their code to work with wallets.
-
-We expect this document to be a stepping stone towards discovering better ways to expose the querying functionality that DApps need in order to function.
+Nontrivial DApps often require the ability to query the network for activity. Algorand DApps written without regard to wallets are likely written using `Algodv2` and `Indexer` from `algosdk`. 
+This document allows DApps to instantiate `Algodv2` and `Indexer` fom a wallet API service, making it easy for JavaScript DApp authors to port their code to work with wallets.
 
 ## Copyright
 

--- a/ARCs/arc-0010.md
+++ b/ARCs/arc-0010.md
@@ -8,7 +8,6 @@ status: Draft
 
 > This API is a draft.
 > Some elements may change.
-> Especially the part about LogicSigs.
 
 ## Summary
 
@@ -17,31 +16,37 @@ An amalgamation of APIs which comprise the minimum requirements for Reach to be 
 ## Abstract
 
 A group of related functions:
-
-* `enable`
-* `signAndPostTxns`
-* `getAlgodv2`
-* `getIndexer`
+* `enable` (**REQUIRED**)
+* `signAndPostTxns` (**REQUIRED**)
+* `getAlgodv2Client` (**REQUIRED**)
+* `getIndexerClient` (**REQUIRED**)
+* `signTxns` (**OPTIONAL**)
+* `postTxns` (**OPTIONAL**)
 
 ## Specification
 
 * `enable`: as specified in [ARC-0006](arc-0006.md).
 * `signAndPostTxns`: as specified in [ARC-0008](arc-0008.md).
-* `getAlgodv2` and `getIndexer`: as specified in [ARC-0009](arc-0009.md).
+* `getAlgodv2Client` and `getIndexerClient`: as specified in [ARC-0009](arc-0009.md).
+* `signTxns`: as specified in [ARC-0005](arc-0005.md) / [ARC-0001](arc-0001.md).
+* `postTxns`: as specified in [ARC-0007](arc-0007.md).
 
 There are additional semantics for using these functions together.
 
 ### Semantic Requirements
 
-* `enable` SHOULD be called before calling the other functions.
-* If `signAndPostTxns`, `getAlgodv2`, or `getIndexer` are called before `enable`, they SHOULD throw an error.
-* `getAlgodv2` and `getIndexer` MUST return connections to the network indicated by the `network` result of `enable`.
-* `signAndPostTxns` MUST post transactions to the network indicated by the `network` result of `enable`
-* The result of `getAlgodv2` SHOULD only be used to query the network. `signAndPostTxns` SHOULD be used to send transactions to the network. The `Algodv2` object MAY be modified to throw exceptions if the caller tries to use it to post transactions.
+* `enable` **SHOULD** be called before calling the other functions and upon refresh of the dApp.
+* If `signAndPostTxns`, `getAlgodv2Client`, `getIndexerClient`, `signTxns`, or `postTxns` are called before `enable`, they **SHOULD** throw an error object with property `code=4202`. (See Error Standards in [ARC-0001](arc-0001.md)).
+* `getAlgodv2Client` and `getIndexerClient` **MUST** return connections to the network indicated by the `network` result of `enable`.
+* `signAndPostTxns` **MUST** post transactions to the network indicated by the `network` result of `enable`
+* The result of `getAlgodv2Client` **SHOULD** only be used to query the network. `postTxns` (if available) and `signAndPostTxns` **SHOULD** be used to send transactions to the network. The `Algodv2Client` object **MAY** be modified to throw exceptions if the caller tries to use it to post transactions.
+* `signTxns` and `postTxns` **MAY** or **MAY NOT** be provided. When one is provided, they both **MUST** be provided. In addition, `signTxns` **MAY** display a warning that the transactions are returned to the dApp rather than posted directly to the blockchain.
 
 ### Additional requirements regarding LogicSigs
 
-`signAndPostTxns` must also be able to handle logic sigs. Callers are expected to sign the logic sig by themselves, rather than expecting the wallet to do so on their behalf. To handle this case, we adopt and extend the [ARC-0001](arc-0001.md) format for `WalletTransaction`s that do not need to be signed:
+`signAndPostTxns` must also be able to handle logic sigs, and more generally transactions signed by the DApp itself. 
+In case of logic sigs, callers are expected to sign the logic sig by themselves, rather than expecting the wallet to do so on their behalf. 
+To handle these cases, we adopt and extend the [ARC-0001](arc-0001.md) format for `WalletTransaction`s that do not need to be signed:
 
 ```json
 {
@@ -52,15 +57,21 @@ There are additional semantics for using these functions together.
 ```
 
 * `stxn` is a `SignedTxnStr`, as specified in [ARC-0007](arc-0007.md).
-* This ARC will likely be updated or extended to require more information about the logic sig in order to allow the wallet to verify that `"txn"` and `"stxn"` match.
+* For production wallets, `stxn` **MUST** be checked to match `txn`, as specified in [ARC-0001](arc-0001.md).
+
+`signAndPostTxns` **MAY** reject when none of the transactions need to be signed by the user.
 
 ## Rationale
 
-In order for a wallet to be useable by Reach, it must support features for account discovery, signing and posting transactions, and querying the network.
+In order for a wallet to be useable by a DApp, it must support features for account discovery, signing and posting transactions, and querying the network.
 
-To whatever extent possible, the end users of a DApp should be empowered to select their own wallet, accounts, and network to be used with the DApp. Furthermore, said users should be able to use their preferred network node connection, without exposing their connection details and secrets (such as endpoint URLs and API tokens) to the DApp.
+To whatever extent possible, the end users of a DApp should be empowered to select their own wallet, accounts, and network to be used with the DApp. 
+Furthermore, said users should be able to use their preferred network node connection, without exposing their connection details and secrets (such as endpoint URLs and API tokens) to the DApp.
 
-It is our intent that the APIs presented in this document and related documents are sufficient to cover the needed functionality, while protecting user choice and remaining compatible with best security practices.
+The APIs presented in this document and related documents are sufficient to cover the needed functionality, while protecting user choice and remaining compatible with best security practices.
+Most DApps indeed always need to post transactions immediately after signing.
+`signAndPostTxns` allows this goal without revealing the signed transactions to the DApp, which prevents surprises to the user: there is no risk the DApp keeps in memory the transactions and post it later without the user knowing it (either to achieve a malicious goal such as forcing double spending, or just because the DApp has a bug).
+However, there are cases where `signTxns` and `postTxns` need to be used: for example when multiple users need to coordinate to sign an atomic transfer.
 
 ## Sample usage
 
@@ -72,7 +83,7 @@ async function main(wallet) {
   const from = enabled.accounts[0];
 
   // Querying
-  const algodv2 = await wallet.getAlgodv2();
+  const algodv2 = new algosdk.Algodv2(await wallet.getAlgodv2());
   const suggestedParams = await algodv2.getTransactionParams().do();
   const txns = makeTxns(from, suggestedParams);
 

--- a/ARCs/arc-0011.md
+++ b/ARCs/arc-0011.md
@@ -15,7 +15,7 @@ A common convention for DApps to discover Algorand wallets in browser code: `win
 
 ## Abstract
 
-A property `algorand` attached to the `window` browser object, with all the features Reach requires of a wallet.
+A property `algorand` attached to the `window` browser object, with all the features defined in [ARC-0010](arc-0010.md).
 
 ## Specification
 
@@ -23,8 +23,10 @@ A property `algorand` attached to the `window` browser object, with all the feat
 interface WindowAlgorand {
   enable: EnableFunction;
   signAndPostTxns: SignAndPostTxnsFunction;
-  getAlgodv2: GetAlgodv2Function;
-  getIndexer: GetIndexerFunction;
+  getAlgodv2Client: GetAlgodv2ClientFunction;
+  getIndexerClient: GetIndexerClientFunction;
+  signTxns?: SignTxnsFunction;
+  postTxns?: SignTxnsFunction;
 }
 ```
 


### PR DESCRIPTION
From #8
with the following changes:
* use of `genesisID`/`genesisHash` instead of `network` for `enable`
* enforce main networks' hashes from genesisID
* allow `enable` to return no account for just access to blockchain
* support of list of group of transactions in posting
* clarify error handling in many cases
* add security considerations in many places
* add optional `signTxns` and `postTxns` to wallet standard
* clarify requirements for confirmation when posting transactions
* use `BaseHTTPClient` from algorand/js-algorand-sdk#477
for `getAlgodv2Client` and `getIndexerClient`
* other minor changes

Include #29  and #28 

Main points to discuss:
* splitting the error standards out of ARC-0001 and make it a living standard
* allow optional argument to post without waiting for confirmation (dangerous)