### PR TITLE
Minor improvements to the ABI

### DIFF
--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -128,26 +128,37 @@ information about methods in IDEs for HLLs.
 
 The JSON structure for such an object is:
 
-```
+```typescript
 interface Method {
+  /** The name of the method */
   name: string,
+  /** Optional, user-friendly description for the method */
   desc?: string,
-  args: Array<{ name?: string, type: string, desc?: string }>,
+  /** The arguments of the method, in order */
+  args: Array<{
+    /** The type of the argument */
+    type: string,
+    /** Optional, user-friendly name for the argument */
+    name?: string,
+    /** Optional, user-friendly description for the argument */
+    desc?: string
+  }>,
+  /** Information about the method's return value */
   returns: { type: string, desc?: string }
 }
 ```
 
 For example:
 
-```
+```json
 {
   "name": "add",
   "desc": "Calculate the sum of two 64-bit integers",
   "args": [
-    { "name": "a", "type": "uint64", "desc": "..." },
-    { "name": "b", "type": "uint64", "desc": "..." }
+    { "type": "uint64", "name": "a", "desc": "The first term to add" },
+    { "type": "uint64", "name": "b", "desc": "The second term to add" }
   ],
-  "returns": { "type": "uint128", "desc": "..." }
+  "returns": { "type": "uint128", "desc": "The sum of a and b" }
 }
 ```
 
@@ -168,21 +179,39 @@ descriptions for each of the methods in the interface.
 
 The JSON structure for such an object is:
 
-```
+```typescript
 interface Interface {
+  /** A user-friendly name for the interface */
   name: string,
-  methods: Array<Method>
+  /** All of the methods that the interface contains */
+  methods: Method[]
 }
 ```
 
 For example:
 
-```
+```json
 {
   "name": "Calculator",
   "methods": [
-    { "name": "add", "args": [...], ... },
-    { "name": "multiply", "args": [...], ... }
+    {
+      "name": "add",
+      "desc": "Calculate the sum of two 64-bit integers",
+      "args": [
+        { "type": "uint64", "name": "a", "desc": "The first term to add" },
+        { "type": "uint64", "name": "b", "desc": "The second term to add" }
+      ],
+      "returns": { "type": "uint128", "desc": "The sum of a and b" }
+    },
+    {
+      "name": "multiply",
+      "desc": "Calculate the product of two 64-bit integers",
+      "args": [
+        { "type": "uint64", "name": "a", "desc": "The first factor to multiply" },
+        { "type": "uint64", "name": "b", "desc": "The second factor to multiply" }
+      ],
+      "returns": { "type": "uint128", "desc": "The product of a and b" }
+    }
   ]
 }
 ```
@@ -217,23 +246,53 @@ descriptions for each of the methods in the contract.
 
 The JSON structure for such an object is:
 
-```
+```typescript
 interface Contract {
+  /** A user-friendly name for the contract */
   name: string,
-  appId: number
-  methods: Array<Method>
+  /**
+   * Optional object listing the contract instances across different networks
+   */
+  networks?: {
+    /**
+     * The key is the base64 genesis hash of the network, and the value contains
+     * the app ID of the deployed contract in that network
+     */
+    [network: string]: { appID: number }
+  }
+  /** All of the methods that the contract implements */
+  methods: Method[]
 }
 ```
 
 For example:
 
-```
+```json
 {
   "name": "Calculator",
-  "appId": 1762763,
+  "networks": {
+    "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=": { "appID": 1234 },
+    "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=": { "appID": 5678 },
+  },
   "methods": [
-    { "name": "add", "args": [...], ... },
-    { "name": "multiply", "args": [...], ... }
+    {
+      "name": "add",
+      "desc": "Calculate the sum of two 64-bit integers",
+      "args": [
+        { "type": "uint64", "name": "a", "desc": "The first term to add" },
+        { "type": "uint64", "name": "b", "desc": "The second term to add" }
+      ],
+      "returns": { "type": "uint128", "desc": "The sum of a and b" }
+    },
+    {
+      "name": "multiply",
+      "desc": "Calculate the product of two 64-bit integers",
+      "args": [
+        { "type": "uint64", "name": "a", "desc": "The first factor to multiply" },
+        { "type": "uint64", "name": "b", "desc": "The second factor to multiply" }
+      ],
+      "returns": { "type": "uint128", "desc": "The product of a and b" }
+    }
   ]
 }
 ```
@@ -249,49 +308,54 @@ information should be stored and its format.
 
 ### Standard Format
 
-The method selector will be the first application call argument,
-accessible as `txn ApplicationArgs 0` from TEAL. For the two special
+The method selector must be the first application call argument (index 0),
+accessible as `txna ApplicationArgs 0` from TEAL. For the two special
 methods `_optIn` and `_closeOut`, the first ApplicationArg **MUST** be
 empty. Instead, the OnCompletion (`apan`) field of the application
 call transaction is set appropriately.
 
-The first 14 method arguments will occupy the next 14 application call
-arguments, accessible from TEAL as `txn ApplicationArgs i` for `1 <= i
-<= 14`. The arguments will be encoded as defined in the Encoding
+If a method has 15 or fewer arguments, each arguments must be placed in
+order in the following application call argument slots (indexes 1 through
+15). The arguments must be encoded as defined in the [Encoding](#encoding)
 section.
 
-If a method has more than 14 arguments, the remaining arguments will
-be encoded as a tuple in the final application call argument,
-accessible from TEAL as `txn ApplicationArgs 15`.
+Otherwise, if a method has 16 or more arguments, the first 14 must be
+placed in order in the following application call argument slots (indexes 1
+through 14), and the remaining arguments must be encoded as a tuple
+in the final application call argument slot (index 15). The arguments must
+be encoded as defined in the [Encoding](#encoding) section.
 
-The return value of the method, if present, will be logged by the
+The return value of the method, if present, must be logged by the
 method implementation. The value is returned by using the `log` opcode
 to log a byte array with a four byte prefix followed by the encoding of
-the value as defined in the Encoding section.  The four byte prefix is
-defined by SHA-512/256("return").  It is 0x151f7c75.
+the value as defined in the [Encoding](#encoding) section. The four byte
+prefix is defined as the first 4 bytes of the SHA-512/256 hash of the ASCII
+string `return`. In hex, this is `151f7c75`. If multiple byte arrays
+with a prefix of `151f7c75` are logged by a method implementation, then
+the latest one is the return value.
 
 
 ### Implementing a Method
 
 An ARC-4 app implementing a method:
 
-1. **MUST** Examine `txn ApplicationArgs 0` to identify the selector
-of the method being invoked. When `txn Application 0` is empty, the
+1. **MUST** Examine `txna ApplicationArgs 0` to identify the selector
+of the method being invoked. When `txna Application 0` is empty, the
 Contract **MAY** inspect OnCompletion to determine if a special method
 is being invoked. If the contract does not implement a method with
 that selector, the call **MUST** fail.
 
-2. branches to the body of the method indicated by the selector
+2. Branches to the body of the method indicated by the selector
 
 3. The code for that method may extract the arguments it needs, if
 any, from the application call arguments as described in the Encoding
-section. If the contract needs to access any method arguments beyond
-the 14th, it must decode `txn ApplicationArgs 15` as a tuple to access
-the arguments contained in it.
+section. If the method has more than 15 arguments and the contract
+needs to extract an argument beyond the 14th, it must decode
+`txna ApplicationArgs 15` as a tuple to access the arguments contained in it.
 
 4. If the method is non-void, the application **MUST** encode the
-return value as described in the Encoding section and then `log` it
-with the prefix 0x151f7c75.
+return value as described in the [Encoding](#encoding) section and then
+`log` it with the prefix `151f7c75`.
 
 
 ### Calling a Method from Off-Chain
@@ -306,10 +370,9 @@ app. The client may now:
     2. Use the selector of the method being invoked as the first
        application call argument.
     3. Encode all arguments for the method, if any, as described in
-       the Encoding section. Place up to 14 method arguments as the
-       next 14 application call arguments. If more than 14 method
-       arguments must be included, encode the remaining as a tuple
-       into the final application call argument.
+       the [Encoding](#encoding) section. If the method has more than 15 arguments,
+       encode all arguments beyond (but not including) the 14th
+       as a tuple into the final application call argument.
 2. Submit this transaction and wait until it successfully commits to
    the blockchain.
 3. Decode the return value, if any, from the ApplyData's log
@@ -408,7 +471,7 @@ Since `string` and `address` are aliases for `byte[]` and `byte[32]`
 respectively (and `byte` is an alias for `uint8`), the rules for
 encoding these types are covered above.
 
-### "Foreign" Types
+### Reference Types
 
 Three special types are supported _only_ as the type of an
 argument. They may not be used in arrays or tuples, as their encoding


### PR DESCRIPTION
This PR contains a small set of improvements to the ABI. I've separated them into two categories:

### Technical changes
* Remove the `appId` field in favor of a new `networks` field on `Contract`. This change has two benefits:
  * A single contract JSON object can now represent a contract deployed to multiple networks, such as to TestNet and MainNet.
  * A contract JSON object can now describe a contract that has not yet been deployed by omitting the `networks` field. Previously the `appId` field was always required.
* If a method has exactly 15 arguments, the last argument is no longer required to be encoded in a tuple.
  * This makes the encoding more efficient for this number of arguments, rather than making the 15th argument appear in a tuple of size 1.
* Clarify that in the case of multiple logged values with the special 4-byte return prefix, the last one is the return value.

### Formatting changes
* Add comments to all JSON definitions and enable code highlighting
* Expand example JSON objects to contain valid fields
* Rename "foreign" types to reference types