### PR TITLE
ARC-0004: Misc changes

### DIFF
--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -593,6 +593,7 @@ a client would create a transaction group containing, in this order:
 1. an asset transfer
 2. a payment
 3. the actual application call
+
 When encoding the other (non-transaction) arguments, the client 
 **MUST** act as if the transaction arguments were completely absent 
 from the method signature. The application call would contain the method 

--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -603,9 +603,9 @@ ApplicationArgs[1], and the fourth (uint32) argument in ApplicationArgs[2].
 
 ARC-4 Apps **SHOULD** be constructed to allow their invocations to be
 combined with other contract invocations in a single atomic group if
-they can do so safely. For example, they **SHOULD** use `txns` to examine
+they can do so safely. For example, they **SHOULD** use `gtxns` to examine
 the previous index in the group for a required `pay` transaction,
-rather than hardcode an index with `txn`.
+rather than hardcode an index with `gtxn`.
 
 In general, an ARC-4 app method with n transactions as arguments **SHOULD** 
 only inspect the n previous transactions. In particular, it **SHOULD NOT**

--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -43,7 +43,7 @@ as described in [RFC-2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 > Comments like this are non-normative.
 
-All strings of type `string` are UTF-8 encoded.
+Interfaces are defined in TypeScript. All the objects that are defined are valid JSON objects, and all JSON `string` types are UTF-8 encoded.
 
 ### Overview
 

--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -509,7 +509,7 @@ encoding these types are covered above.
 ### Reference Types
 
 Three special types are supported _only_ as the type of an
-argument. They **MUST** not be embedded in arrays or tuples, as 
+argument. They **MUST NOT* be embedded in arrays or tuples, as 
 their encoding is unusual. (They **MAY** implicitely be part of
 a tuple if they are the type of the 15-th argument or an argument
 further away.)

--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -11,7 +11,8 @@ status: Draft
 ## Summary
 
 A standard for encoding contract call transactions to invoke methods
-on an Algorand _Smart Contract_ (aka "stateful contract" or "app").
+on an Algorand _Smart Contract_ (aka "stateful contract", "contract",
+"application", or "app").
 
 ## Abstract
 
@@ -165,21 +166,21 @@ For example:
 
 ### Interfaces
 
-An interface is a logically grouped set of methods. All method selectors in an
-interface **MUST** be unique. Method names **MAY** not be unique, as long as
-the corresponding method selectors are different. Method names in interfaces 
+An Interface is a logically grouped set of methods. All method selectors in an
+Interface **MUST** be unique. Method names **MAY** not be unique, as long as
+the corresponding method selectors are different. Method names in Interfaces 
 **MUST NOT** begin with an underscore.
 
-A smart contract *implements* an interface if it supports
-all of the methods from that interface. A smart contract **MAY** implement
-zero, one, or multiple interfaces.
+A smart contract *implements* an Interface if it supports
+all of the methods from that Interface. A smart contract **MAY** implement
+zero, one, or multiple Interfaces.
 
 Interfaces designer **SHOULD** try to prevent collisions of method selectors 
-between interfaces that are likely to be implemented together by the same 
+between Interfaces that are likely to be implemented together by the same 
 application.
 
-> For example, if an interface `Calculator` providing addition and subtraction
-> of integer methods and an interface `NumberFormating` providing formatting
+> For example, if an Interface `Calculator` providing addition and subtraction
+> of integer methods and an Interface `NumberFormating` providing formatting
 > methods for numbers into strings are likely to be used together.
 > Interface designers should ensure that all the methods in `Calculator` and
 > `NumberFormatting` have a distinct method selector
@@ -187,8 +188,8 @@ application.
 
 #### Interface Description
 
-An interface description is a JSON object containing the JSON
-descriptions for each of the methods in the interface.
+An Interface description is a JSON object containing the JSON
+descriptions for each of the methods in the Interface.
 
 The JSON structure for such an object is:
 
@@ -239,26 +240,26 @@ For example:
 
 ### Contracts
 
-A contract is the complete set of methods that an app implements. It
+A Contract is the complete set of methods that an app implements. It
 is similar to an interface, but may include further details about the
 concrete implementation. All method selectors in a Contract **MUST** be 
 unique. Method names **MAY** not be unique, as long as
 the corresponding method selectors are different. Method names in 
-Contracts **MAY** begin with underscore, but these names are reserved 
-for use by this ARC and future ABI-related ARCs.
+Contract names **MAY** begin with underscore, but these names are 
+reserved for use by this ARC and future ABI-related ARCs.
 
-A contract **MAY** contain two special methods, named `_optIn` and
+A Contract **MAY** contain two special methods, named `_optIn` and
 `_closeOut`. These methods describe how callers can opt-in to
 (allocate local state), or close-out from (deallocate local state),
 such apps. They **MAY** have any arguments or return values, but there
 **MUST** be no more than one method with each name.
 
-In the absence of such methods, ARC-4 Contracts **SHOULD** allow
+In the absence of such methods, ARC-4 contracts **SHOULD** allow
 accounts to perform the corresponding action with no arguments, or by
 setting the associated OnCompletion value (OptIn = 1, CloseOut = 2)
-while calling a method of the contract. ARC-4 Contracts **MAY** allow
+while calling a method of the Contract. ARC-4 contracts **MAY** allow
 OnCompletion values to be set to other values in order to support
-methods that delete or update the contract. Of course, great care
+methods that delete or update the Contract. Of course, great care
 should be taken when allowing these operations.
 
 The method selectors for `_optIn` and `_closeOut` **MAY** not be unique.
@@ -270,8 +271,8 @@ The method selectors for `_optIn` and `_closeOut` **MAY** not be unique.
 
 #### Contract Description
 
-A contract description is a JSON object containing the JSON
-descriptions for each of the methods in the contract.
+A Contract description is a JSON object containing the JSON
+descriptions for each of the methods in the Contract.
 
 The JSON structure for such an object is:
 

--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -42,6 +42,8 @@ as described in [RFC-2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 > Comments like this are non-normative.
 
+All strings of type `string` are UTF-8 encoded.
+
 ### Overview
 
 This document makes recommendations for encoding method invocations as
@@ -72,23 +74,21 @@ encoded byte arrays conveniently in the AVM.
 
 #### Method Signature
 
-> Would people prefer "Method prototype" here in order to avoid using
-> the word "signature" again?
-
 A method signature is a unique identifier for a method. The signature
 is a string that consists of the method's name, an open parenthesis, a
 comma-separated list of the types of its arguments, a closing
 parenthesis, and the method's return type, or `void` if it does not
-return a value. The names of arguments are _not_ included in a
-method's signature, and whitespace does not appear anywhere.
+return a value. The names of arguments **MUST NOT** included in a
+method's signature, and **MUST NOT** contain any whitespace.
 
 For example, `add(uint64,uint64)uint128` is the method signature for a
 method named `add` which takes two uint64 parameters and returns a
-uint128.  Signatures are encoded in utf-8, and method names may not
-contain an open parenthesis or whitespace. For the benefit of
-universal interoperability (especially in HLLs) and to avoid collision
-with ARC-4 reserved methods, names should be further restricted by the
-regular expression `[A-Za-z][A-Za-z0-9_]*`.
+uint128. Signatures are encoded in ASCII. 
+
+For the benefit of universal interoperability (especially in HLLs), 
+names **MUST** satisfy the regular expression `[_A-Za-z][A-Za-z0-9_]*`.
+Names starting with an underscore are reserved and **MUST** only
+be used as specified in this ARC or future ABI-related ARC.
 
 
 #### Method Selector
@@ -165,12 +165,25 @@ For example:
 
 ### Interfaces
 
-An interface is a logically grouped set of methods. All methods in an
-interface must be unique (specifically, they must have unique method
-selectors). Method names in interfaces **MUST NOT** begin with an
-underscore. A smart contract implements an interface if it supports
-all of the methods from that interface. A smart contract may implement
+An interface is a logically grouped set of methods. All method selectors in an
+interface **MUST** be unique. Method names **MAY** not be unique, as long as
+the corresponding method selectors are different. Method names in interfaces 
+**MUST NOT** begin with an underscore.
+
+A smart contract *implements* an interface if it supports
+all of the methods from that interface. A smart contract **MAY** implement
 zero, one, or multiple interfaces.
+
+Interfaces designer **SHOULD** try to prevent collisions of method selectors 
+between interfaces that are likely to be implemented together by the same 
+application.
+
+> For example, if an interface `Calculator` providing addition and subtraction
+> of integer methods and an interface `NumberFormating` providing formatting
+> methods for numbers into strings are likely to be used together.
+> Interface designers should ensure that all the methods in `Calculator` and
+> `NumberFormatting` have a distinct method selector
+
 
 #### Interface Description
 
@@ -183,16 +196,24 @@ The JSON structure for such an object is:
 interface Interface {
   /** A user-friendly name for the interface */
   name: string,
+  /** Optional, user-friendly description for the interface */
+  desc?: string,
   /** All of the methods that the interface contains */
   methods: Method[]
 }
 ```
+
+Interface names **MUST** satisfy the regular expression `[_A-Za-z][A-Za-z0-9_]*`.
+Interface names starting by `ARC` are reserved to interfaces defined in ARC.
+Interfaces defined in `ARC-XXXX` (where `XXXX` is a 0-padded number) **SHOULD**
+start with `ARC-XXXX`.
 
 For example:
 
 ```json
 {
   "name": "Calculator",
+  "desc": "Interface for a basic calculator supporting additions and multiplications",
   "methods": [
     {
       "name": "add",
@@ -218,18 +239,19 @@ For example:
 
 ### Contracts
 
-A Contract is the complete set of methods that an app implements. It
+A contract is the complete set of methods that an app implements. It
 is similar to an interface, but may include further details about the
-concrete implementation. All methods in a Contract must be unique
-(specifically, they must have unique method selectors). Method names
-in Contracts **MAY** begin with underscore, but these names are
-reserved for use by this ARC and its future revisions.
+concrete implementation. All method selectors in a Contract **MUST** be 
+unique. Method names **MAY** not be unique, as long as
+the corresponding method selectors are different. Method names in 
+Contracts **MAY** begin with underscore, but these names are reserved 
+for use by this ARC and future ABI-related ARCs.
 
-A Contract may contain two special methods, `_optIn` and
+A contract **MAY** contain two special methods, named `_optIn` and
 `_closeOut`. These methods describe how callers can opt-in to
 (allocate local state), or close-out from (deallocate local state),
-such apps.  They may have any arguments or return values, but there
-must be no more than one method with each name.
+such apps. They **MAY** have any arguments or return values, but there
+**MUST** be no more than one method with each name.
 
 In the absence of such methods, ARC-4 Contracts **SHOULD** allow
 accounts to perform the corresponding action with no arguments, or by
@@ -238,6 +260,13 @@ while calling a method of the contract. ARC-4 Contracts **MAY** allow
 OnCompletion values to be set to other values in order to support
 methods that delete or update the contract. Of course, great care
 should be taken when allowing these operations.
+
+The method selectors for `_optIn` and `_closeOut` **MAY** not be unique.
+> This is because these method selectors are not used when calling the contract.
+
+> Note that the above allows to opt-in and call a method in one application
+> call rather than requiring two transactions. This improves
+> efficiency in many situations.
 
 #### Contract Description
 
@@ -250,6 +279,8 @@ The JSON structure for such an object is:
 interface Contract {
   /** A user-friendly name for the contract */
   name: string,
+  /** Optional, user-friendly description for the interface */
+  desc?: string,
   /**
    * Optional object listing the contract instances across different networks
    */
@@ -265,11 +296,14 @@ interface Contract {
 }
 ```
 
+Contract names **MUST** satisfy the regular expression `[_A-Za-z][A-Za-z0-9_]*`.
+
 For example:
 
 ```json
 {
   "name": "Calculator",
+  "desc": "Contract of a basic calculator supporting additions and multiplications. Implements the Calculator interface.",
   "networks": {
     "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=": { "appID": 1234 },
     "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=": { "appID": 5678 },
@@ -314,18 +348,18 @@ methods `_optIn` and `_closeOut`, the first ApplicationArg **MUST** be
 empty. Instead, the OnCompletion (`apan`) field of the application
 call transaction is set appropriately.
 
-If a method has 15 or fewer arguments, each arguments must be placed in
+If a method has 15 or fewer arguments, each arguments **MUST** be placed in
 order in the following application call argument slots (indexes 1 through
-15). The arguments must be encoded as defined in the [Encoding](#encoding)
+15). The arguments **MUST** be encoded as defined in the [Encoding](#encoding)
 section.
 
-Otherwise, if a method has 16 or more arguments, the first 14 must be
+Otherwise, if a method has 16 or more arguments, the first 14 **MUST** be
 placed in order in the following application call argument slots (indexes 1
-through 14), and the remaining arguments must be encoded as a tuple
+through 14), and the remaining arguments **MUST** be encoded as a tuple
 in the final application call argument slot (index 15). The arguments must
 be encoded as defined in the [Encoding](#encoding) section.
 
-The return value of the method, if present, must be logged by the
+The return value of the method, if present, **MUST** be logged by the
 method implementation. The value is returned by using the `log` opcode
 to log a byte array with a four byte prefix followed by the encoding of
 the value as defined in the [Encoding](#encoding) section. The four byte
@@ -339,7 +373,7 @@ the latest one is the return value.
 
 An ARC-4 app implementing a method:
 
-1. **MUST** Examine `txna ApplicationArgs 0` to identify the selector
+1. **MUST** examine `txna ApplicationArgs 0` to identify the selector
 of the method being invoked. When `txna Application 0` is empty, the
 Contract **MAY** inspect OnCompletion to determine if a special method
 is being invoked. If the contract does not implement a method with
@@ -347,10 +381,10 @@ that selector, the call **MUST** fail.
 
 2. Branches to the body of the method indicated by the selector
 
-3. The code for that method may extract the arguments it needs, if
+3. The code for that method **MAY** extract the arguments it needs, if
 any, from the application call arguments as described in the Encoding
 section. If the method has more than 15 arguments and the contract
-needs to extract an argument beyond the 14th, it must decode
+needs to extract an argument beyond the 14th, it **MUST** decode
 `txna ApplicationArgs 15` as a tuple to access the arguments contained in it.
 
 4. If the method is non-void, the application **MUST** encode the
@@ -411,6 +445,7 @@ The following types are supported in the Algorand ABI.
 * `<type>[]`: A variable-length array. `type` can be any other type.
 * `string`: A variable-length byte array (`byte[]`) assumed to contain UTF-8 encoded content.
 * `(T1,T2,...,TN)`: A tuple of the types `T1`, `T2`, …, `TN`, `N >= 0`.
+* reference types `account`, `asset`, `application`: only for arguments, in which case they are an alias for `uint8`. See section "Reference Types" below.
 
 ### Static vs Dynamic Types
 
@@ -474,8 +509,10 @@ encoding these types are covered above.
 ### Reference Types
 
 Three special types are supported _only_ as the type of an
-argument. They must not be embedded in arrays or tuples, as their
-encoding is unusual.
+argument. They **MUST** not be embedded in arrays or tuples, as 
+their encoding is unusual. (They **MAY** implicitely be part of
+a tuple if they are the type of the 15-th argument or an argument
+further away.)
 
 * `account` represents an Algorand account, stored in the Accounts (`apat`) array
 * `asset` represents an Algorand Standard Asset (ASA), stored in the Foreign Assets (`apas`) array
@@ -510,7 +547,7 @@ An ARC-4 app **SHOULD** allow accounts to opt-in and close-out, using
 an application call transaction with no arguments an OnCompletion
 equal to OptIn (1) or CloseOut (2). Clients **MAY** determine that
 opt-in is unnecessary by querying the blockchain for the app's
-schema. Opt-in is unnecessary if the app has no local schema.  However,
+schema. Opt-in is unnecessary if the app has no local schema. However,
 even if a local schema is present, some methods may be callable
 without opt-in. Clients **MAY** attempt method calls without opt-in
 and use the failure response to learn that opt-in is required.
@@ -521,11 +558,7 @@ an ARC-4 app **SHOULD** interpret the arguments as an invocation as
 described in the rest of this document, to perform along with the
 opt-in or close-out.
 
-> Should the ABI allow contracts to specify which methods require
-> opt-in?
-
-
-### Transaction types.
+### Transaction types
 
 Some apps require that they are invoked as part of a larger
 transaction group, containing specific additional transactions.  Seven
@@ -555,42 +588,40 @@ group, which is undesirable. Instead, the locations of the
 transactions are implied entirely by the placement of the transaction
 types in the argument list.
 
-For example, to invoke the method `deposit(string,axfer,uint32)void`,
-a client would create a transaction group containing an asset transfer
-followed by the application call.  When encoding the other
-(non-transaction) arguments, the client should act as if the
-transaction arguments were completely absent from the method
-signature.  The application call would contain the method selector in
-ApplicationArgs[0], the first (string) argument in ApplicationArgs[1],
-and the third (uint32) argument in ApplicationArgs[2].
-
-> Further questions: Should it be possible to describe requirements of
-> certain fields of the transactions named this way? For example, can
-> the amount of recipient of a pay transaction be specified? A
-> specific, important instance of this problem: How can logicsigs on
-> these transactions be provided in the JSON interface?
+For example, to invoke the method `deposit(string,axfer,pay,uint32)void`,
+a client would create a transaction group containing, in this order:
+1. an asset transfer
+2. a payment
+3. the actual application call
+When encoding the other (non-transaction) arguments, the client 
+**MUST** act as if the transaction arguments were completely absent 
+from the method signature. The application call would contain the method 
+selector in ApplicationArgs[0], the first (string) argument in 
+ApplicationArgs[1], and the fourth (uint32) argument in ApplicationArgs[2].
 
 
 ARC-4 Apps **SHOULD** be constructed to allow their invocations to be
 combined with other contract invocations in a single atomic group if
-they can do so safely. For example, they should use `txns` to examine
+they can do so safely. For example, they **SHOULD** use `txns` to examine
 the previous index in the group for a required `pay` transaction,
 rather than hardcode an index with `txn`.
 
-## New Features in support of the ABI
+In general, an ARC-4 app method with n transactions as arguments **SHOULD** 
+only inspect the n previous transactions. In particular, it **SHOULD NOT**
+inspect transactions after and it **SHOULD NOT** check the size of a transaction 
+group (if this can be done safely). 
+In addition, a given method **SHOULD** always expect the same
+number of transactions before itself. For example, the method 
+`deposit(string,axfer,pay,uint32)` is always preceded by two transactions.
+It is never the case that it can be called only with one asset transfer
+but no payment transfer.
 
-Some changes are needed to the Algorand protocol and its tools to
-better support this ABI:
+> The reason for the above recommendation is to provide minimal
+> composability support while preventing obvious dangerous attacks.
+> For example, if some apps expect payment transactions after them
+> while other expect payment transaction before them, then the same
+> payment may be counted twice.
 
-* The `log` opcode can be used to return a value.
-    * Tracked by [https://github.com/algorand/go-algorand/issues/2349](https://github.com/algorand/go-algorand/issues/2349)
-* The `extract*` opcodes simplify access to uints embedded in strings.
-    * Tracked by [https://github.com/algorand/go-algorand/issues/2347](https://github.com/algorand/go-algorand/issues/2347)
-* A way for indexer to search transactions based on app args (and possibly return value) would be useful to search for calls to specific methods.
-* SDKs will need to calculate the method signature and selector for methods given a JSON description of the method/interface.
-* The `method` pseudo-op, akin to `addr`, takes a function signature as a string, but inserts the method selector (as bytes) into the program.
-    * Tracked by [https://github.com/algorand/go-algorand/pull/2358](https://github.com/algorand/go-algorand/pull/2358)
-* A way for apps to call other apps is needed to support calling a method from another contract.
 
 ## Copyright
 

--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -613,7 +613,7 @@ inspect transactions after and it **SHOULD NOT** check the size of a transaction
 group (if this can be done safely). 
 In addition, a given method **SHOULD** always expect the same
 number of transactions before itself. For example, the method 
-`deposit(string,axfer,pay,uint32)` is always preceded by two transactions.
+`deposit(string,axfer,pay,uint32)void` is always preceded by two transactions.
 It is never the case that it can be called only with one asset transfer
 but no payment transfer.
 

--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -206,7 +206,7 @@ interface Interface {
 Interface names **MUST** satisfy the regular expression `[_A-Za-z][A-Za-z0-9_]*`.
 Interface names starting by `ARC` are reserved to interfaces defined in ARC.
 Interfaces defined in `ARC-XXXX` (where `XXXX` is a 0-padded number) **SHOULD**
-start with `ARC-XXXX`.
+start with `ARC_XXXX`.
 
 For example:
 


### PR DESCRIPTION
Changes:
* minor style changes, in particular using **MUST**…
* allow descriptions `desc` in interfaces and contracts
* add comment that interfaces designer should be mindful to prevent collisions of method selectors between interfaces that are likely to be implemented together by the same application.
* clarify that method names do not need to be uniq
* restrict contract and interface names to Interface to  `[_A-Za-z][A-Za-z0-9_]*` , which would be useful if later we want to say that contract XXX implements interface YYY. Allowing full UTF-8 or spaces can quickly make things cumbersome.
* make interface names `ARC-XXXX...` reserved for ARCs
* allow method selector for `_optIn` and `_closeOut` to not be unique
* add a note that reference types can be part of a tuple is in the 15-th argument or after
* clarifying the order of transactions using two possibles transactions
* enforce some additional rules when
* removing the section “New Features in support of the ABI”
* removed the questions and moving them there: https://github.com/algorandfoundation/ARCs/issues/44