### PR TITLE
ARC-0004: Change how contract creation and OnCompletion actions work

### DIFF
--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -60,14 +60,14 @@ an application call transaction. A method must have a name, it may
 take a list of arguments as input when it is invoked, and it may
 return a single value (which may be a tuple) when it finishes
 running. The possible types for arguments and return values are
-described later.
+described later in the [Encoding](#encoding) section.
 
 Invoking a method involves creating an application call transaction to
 specifically call that method. Methods are different from internal
-"helper functions" that may exist in a contract, but are not
-externally callable. In the future, applications will be able to invoke
-methods from other applications, so it should be possible to build ABI
-encoded byte arrays conveniently in the AVM.
+subroutines that may exist in a contract, but are not externally
+callable. Methods may be invoked by a top-level application call
+transaction from an off-chain caller, or by an application call inner
+transaction created by another smart contract.
 
 
 #### Method Signature
@@ -117,8 +117,8 @@ beyond its signature. This description is encoded in JSON and consists
 of a method's name, description, arguments (their types, names, and
 descriptions), and return type (and possible description for the
 return type). From this structure, the method's signature and selector
-can be calculated. The Algorand SDKs will provide convenience
-functions to calculate signatures and selectors from such JSON files.
+can be calculated. The Algorand SDKs provide convenience functions
+to calculate signatures and selectors from such JSON files.
 
 These details will enable high-level languages and dapps/wallets to
 properly encode arguments, call methods, and decode return
@@ -219,25 +219,62 @@ For example:
 ### Contracts
 
 A Contract is the complete set of methods that an app implements. It
-is similar to an interface, but may include further details about the
-concrete implementation. All methods in a Contract must be unique
-(specifically, they must have unique method selectors). Method names
-in Contracts **MAY** begin with underscore, but these names are
-reserved for use by this ARC and its future revisions.
+is similar to an interface, but it may include further details about the
+concrete implementation, as well as implementation-specific methods that
+do not belong to any interface. All methods in a Contract **MUST** be
+unique; specifically, each method **MUST** have a unique method selector.
 
-A Contract may contain two special methods, `_optIn` and
-`_closeOut`. These methods describe how callers can opt-in to
-(allocate local state), or close-out from (deallocate local state),
-such apps.  They may have any arguments or return values, but there
-must be no more than one method with each name.
+Method names in Contracts **MAY** begin with underscore, but these
+names are reserved for use by this ARC and its future revisions.
 
-In the absence of such methods, ARC-4 Contracts **SHOULD** allow
-accounts to perform the corresponding action with no arguments, or by
-setting the associated OnCompletion value (OptIn = 1, CloseOut = 2)
-while calling a method of the contract. ARC-4 Contracts **MAY** allow
-OnCompletion values to be set to other values in order to support
-methods that delete or update the contract. Of course, great care
-should be taken when allowing these operations.
+#### OnCompletion Actions and Creation
+
+In addition to the set of methods from the Contract's definition,
+a Contract **MAY** allow application calls with zero arguments, also
+known as bare application calls. Since method invocations with zero
+arguments still encode the method selector as the first application
+call arguments, bare application calls are always distinguishable
+from method invocations.
+
+The primary purpose of bare application calls is to allow the
+execution of an OnCompletion (`apan`) action which requires no
+inputs and has no return value. A Contract **MAY** allow this
+for all OnCompletion actions, for only a subset of them, or for
+none at all. Great care should be taken when allowing these
+operations.
+
+If a Contract elects to allow bare application calls for some
+OnCompletion actions, then that Contract **SHOULD** also allow
+any of its methods to be called with those OnCompletion actions,
+as long as this would not cause undesirable or nonsensical behavior.
+
+> The reason for this is because if it's acceptable to allow an
+> OnCompletion action to take place in isolation inside of a bare
+> application call, then it's most likely acceptable to allow
+> the same action to take place at the same time as an ABI method
+> call. And since the latter can be accomplished in just one
+> transaction, it can be more efficient.
+
+If a Contract requires an OnCompletion action to take inputs or
+to return a value, then the **RECOMMENDED** behavior of the Contract
+should be to not allow bare application calls for that OnCompletion
+action. Rather, the Contract should have one or more methods that
+are meant to be called with the appropriate OnCompletion action set
+in order to process that action.
+
+If a Contract is called with greater than zero application call
+arguments (**NOT** a bare application call), the Contract **MUST**
+always treat the first argument as a method selector and invoke
+the specified method, regardless of the OnCompletion action of
+the application call. This applies to application creation
+transactions as well, where the supplied application ID is 0.
+
+Similar to OnCompletion actions, if a Contract requires its
+creation transaction to take inputs or to return a value, then
+the **RECOMMENDED** behavior of the Contract should be to not
+allow bare application calls for creation. Rather, the Contract
+should have one or more methods that are meant to be called
+in order to create the Contract.
 
 #### Contract Description
 
@@ -309,10 +346,8 @@ information should be stored and its format.
 ### Standard Format
 
 The method selector must be the first application call argument (index 0),
-accessible as `txna ApplicationArgs 0` from TEAL. For the two special
-methods `_optIn` and `_closeOut`, the first ApplicationArg **MUST** be
-empty. Instead, the OnCompletion (`apan`) field of the application
-call transaction is set appropriately.
+accessible as `txna ApplicationArgs 0` from TEAL (except for bare application
+calls, which use zero application call arguments).
 
 If a method has 15 or fewer arguments, each arguments must be placed in
 order in the following application call argument slots (indexes 1 through
@@ -325,48 +360,62 @@ through 14), and the remaining arguments must be encoded as a tuple
 in the final application call argument slot (index 15). The arguments must
 be encoded as defined in the [Encoding](#encoding) section.
 
-The return value of the method, if present, must be logged by the
-method implementation. The value is returned by using the `log` opcode
-to log a byte array with a four byte prefix followed by the encoding of
-the value as defined in the [Encoding](#encoding) section. The four byte
-prefix is defined as the first 4 bytes of the SHA-512/256 hash of the ASCII
-string `return`. In hex, this is `151f7c75`. If multiple byte arrays
-with a prefix of `151f7c75` are logged by a method implementation, then
-the latest one is the return value.
+If a method has a non-void return type, then the return value of the method
+**MUST** be located in the final logged value of the method's execution,
+using the `log` opcode. The logged value **MUST** contain a specific 4 byte
+prefix, followed by the encoding of the return value as defined in the 
+[Encoding](#encoding) section. The 4 byte prefix is defined as the first 4 
+bytes of the SHA-512/256 hash of the ASCII string `return`. In hex, this is
+`151f7c75`.
 
+> For example, if the method `add(uint64,uint64)uint128` wanted to return the
+> value 4160, it would log the byte array `151f7c7500000000000000000000000000001040`
+> (shown in hex).
 
 ### Implementing a Method
 
 An ARC-4 app implementing a method:
 
-1. **MUST** Examine `txna ApplicationArgs 0` to identify the selector
-of the method being invoked. When `txna Application 0` is empty, the
-Contract **MAY** inspect OnCompletion to determine if a special method
-is being invoked. If the contract does not implement a method with
-that selector, the call **MUST** fail.
+1. **MUST** check if `txn NumAppArgs` equals 0. If true, then this is a
+bare application call. If the Contract supports bare application calls
+for the current transaction parameters (it **SHOULD** check the OnCompletion
+action and whether the transaction is creating the application), it **MUST**
+handle the call appropriately and either approve or reject the transaction.
+The following steps **MUST** be ignored in this case. Otherwise, if
+the Contract does not support this bare application call, the Contract
+**MUST** reject the transaction.
 
-2. Branches to the body of the method indicated by the selector
+2. **MUST** examine `txna ApplicationArgs 0` to identify the selector
+of the method being invoked. If the contract does not implement a method with
+that selector, the Contract **MUST** reject the transaction.
 
-3. The code for that method may extract the arguments it needs, if
-any, from the application call arguments as described in the Encoding
+3. **MUST** execute the actions required to implement the method being
+invoked. In general, this works by branching to the body of the method
+indicated by the selector.
+
+4. The code for that method **MAY** extract the arguments it needs, if
+any, from the application call arguments as described in the [Encoding](#encoding)
 section. If the method has more than 15 arguments and the contract
-needs to extract an argument beyond the 14th, it must decode
+needs to extract an argument beyond the 14th, it **MUST** decode
 `txna ApplicationArgs 15` as a tuple to access the arguments contained in it.
 
 4. If the method is non-void, the application **MUST** encode the
 return value as described in the [Encoding](#encoding) section and then
-`log` it with the prefix `151f7c75`.
+`log` it with the prefix `151f7c75`. Other values **MAY** be logged
+before the return value, but other values **MUST NOT** be logged after
+the return value.
 
 
 ### Calling a Method from Off-Chain
 
 To invoke an ARC-4 app, an off-chain system, such as a dapp or wallet,
-would first obtain the interface description JSON object for the
-app. The client may now:
+would first obtain the Interface or Contract description JSON object
+for the app. The client may now:
 
 1. Create an application call transaction with the following parameters:
-    1. Use the ID of the desired application whose approval program
-       implements the method being invoked.
+    1. Use the ID of the desired application whose program code
+       implements the method being invoked, or 0 if they wish to
+       create the application.
     2. Use the selector of the method being invoked as the first
        application call argument.
     3. Encode all arguments for the method, if any, as described in
@@ -379,6 +428,14 @@ app. The client may now:
    information.
 
 Clients **MAY** ignore the return value.
+
+An exception to the above instructions is if the app supports bare
+application calls for some transaction parameters, and the client
+wishes to invoke this functionality. Then the client may simply create
+and submit to the network an application call transaction with the ID of
+the application (or 0 if they wish to create the application) and the
+desired OnCompletion value set. Application arguments **MUST NOT** be
+present.
 
 ## Encoding
 
@@ -411,6 +468,9 @@ The following types are supported in the Algorand ABI.
 * `<type>[]`: A variable-length array. `type` can be any other type.
 * `string`: A variable-length byte array (`byte[]`) assumed to contain UTF-8 encoded content.
 * `(T1,T2,...,TN)`: A tuple of the types `T1`, `T2`, …, `TN`, `N >= 0`.
+
+Additional special use types are defined in [Reference Types](#reference-types)
+and [Transaction Types](#transaction-types).
 
 ### Static vs Dynamic Types
 
@@ -503,29 +563,7 @@ accessed by such opcodes, ARC-4 Contracts **SHOULD** use the base
 types for passing these types: `address` for accounts and `uint64`
 for asset or application IDs.
 
-
-### Opt In, Close Out, and Clear State.
-
-An ARC-4 app **SHOULD** allow accounts to opt-in and close-out, using
-an application call transaction with no arguments an OnCompletion
-equal to OptIn (1) or CloseOut (2). Clients **MAY** determine that
-opt-in is unnecessary by querying the blockchain for the app's
-schema. Opt-in is unnecessary if the app has no local schema.  However,
-even if a local schema is present, some methods may be callable
-without opt-in. Clients **MAY** attempt method calls without opt-in
-and use the failure response to learn that opt-in is required.
-
-Clients **MAY** display the minimum balance increment that such an
-opt-in would require.  If an opt-in or close-out contains arguments,
-an ARC-4 app **SHOULD** interpret the arguments as an invocation as
-described in the rest of this document, to perform along with the
-opt-in or close-out.
-
-> Should the ABI allow contracts to specify which methods require
-> opt-in?
-
-
-### Transaction types.
+### Transaction Types
 
 Some apps require that they are invoked as part of a larger
 transaction group, containing specific additional transactions.  Seven


### PR DESCRIPTION
In order to simplify and make more consistent how contract creation and OnCompletion actions work, this PR removes the special methods `_optIn` and `_closeOut`. In their place, I've explicitly defined "bare application calls" and provided guidance for how and when they should be supported.

The general idea is that if your app creation call or OnCompletion action requires no arguments and no return value, then your contract **SHOULD** implement these operations as bare application calls. Otherwise, if there are some situations in which you require arguments or a return value, your contract **SHOULD NOT** allow bare application calls for this case, and instead provide one or more ABI methods which can be called with the appropriate action.

Additionally, in order to make it easier to read the return value of a contract-to-contract ABI method call, this PR requires the return value logged item to be the _final_ logged item by an application execution.