### PR TITLE
ARC-0004 Minor clarifications and last call

### DIFF
--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -1,7 +1,7 @@
 ---
 arc: 4
 title: Algorand Application Binary Interface (ABI)
-status: Draft
+status: Last Call
 ---
 
 # Algorand Transaction Calling Conventions

--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -11,27 +11,28 @@ status: Draft
 ## Summary
 
 A standard for encoding contract call transactions to invoke methods
-on an Algorand _Smart Contract_ (aka "stateful contract", "contract",
-"application", or "app").
+on an Algorand _Applications_ (aka "smart contracts").
 
 ## Abstract
 
 This document introduces conventions for encoding method calls,
-including argument and return value encoding, in Algorand application
+including argument and return value encoding, in Algorand Application
 call transactions. The goal is to allow clients, such as wallets and
-dapps, to properly encode call transactions based on a description of
-the interface. Further, explorers will be able to show details of
+dapp frontends, to properly encode call transactions based on a description 
+of the interface. Further, explorers will be able to show details of
 these method invocations.
 
 ## Definitions
 
+* **Application:** an Algorand Application, aka "smart contract", 
+  "stateful contract", "contract", or "app".
 * **HLL:** a higher level language that compiles to TEAL bytecode.
-* **dapp**: a decentralized application, interpreted here to mean an
-  off-chain application (a webapp, native app, etc.) that interacts
-  with smart contracts on the blockchain.
-* **wallet**: an application that stores secret keys for on-chain
+* **dapp (frontend)**: a decentralized application frontend, interpreted here to
+  mean an off-chain frontend (a webapp, native app, etc.) that interacts with
+  Applications on the blockchain.
+* **wallet**: an off-chain application that stores secret keys for on-chain
   accounts and can display and sign transactions for these accounts.
-* **explorer**: an application that allows browsing the blockchain,
+* **explorer**: an off-chain application that allows browsing the blockchain,
   showing details of transactions.
 
 ## Specification
@@ -43,33 +44,34 @@ as described in [RFC-2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 > Comments like this are non-normative.
 
-Interfaces are defined in TypeScript. All the objects that are defined are valid JSON objects, and all JSON `string` types are UTF-8 encoded.
+Interfaces are defined in TypeScript. All the objects that are defined 
+are valid JSON objects, and all JSON `string` types are UTF-8 encoded.
 
 ### Overview
 
 This document makes recommendations for encoding method invocations as
-application call transactions, and for describing methods for
+Application call transactions, and for describing methods for
 access by higher-level entities.  Encoding recommendations are
 intended to be minimal, intended only to allow interoperability among
-contracts.  Higher level recommendations are intended to enhance
+Applications.  Higher level recommendations are intended to enhance
 user-facing interfaces, such as high-level language, dapps, and
-wallets.  Apps that follow the recommendations described here are called
-_ARC-4 Apps_.
+wallets.  Applications that follow the recommendations described here are 
+called _ARC-4 Applications_.
 
 ### Methods
 
 A method is a section of code intended to be invoked externally with
-an application call transaction. A method must have a name, it may
+an Application call transaction. A method must have a name, it may
 take a list of arguments as input when it is invoked, and it may
 return a single value (which may be a tuple) when it finishes
 running. The possible types for arguments and return values are
 described later in the [Encoding](#encoding) section.
 
-Invoking a method involves creating an application call transaction to
+Invoking a method involves creating an Application call transaction to
 specifically call that method. Methods are different from internal
 subroutines that may exist in a contract, but are not externally
-callable. Methods may be invoked by a top-level application call
-transaction from an off-chain caller, or by an application call inner
+callable. Methods may be invoked by a top-level Application call
+transaction from an off-chain caller, or by an Application call inner
 transaction created by another smart contract.
 
 
@@ -171,19 +173,19 @@ Interface **MUST** be unique. Method names **MAY** not be unique, as long as
 the corresponding method selectors are different. Method names in Interfaces 
 **MUST NOT** begin with an underscore.
 
-A smart contract *implements* an Interface if it supports
-all of the methods from that Interface. A smart contract **MAY** implement
+An Algorand Application *implements* an Interface if it supports
+all of the methods from that Interface. An Application **MAY** implement
 zero, one, or multiple Interfaces.
 
 Interfaces designer **SHOULD** try to prevent collisions of method selectors 
 between Interfaces that are likely to be implemented together by the same 
-application.
+Application.
 
-> For example, if an Interface `Calculator` providing addition and subtraction
+> For example, an Interface `Calculator` providing addition and subtraction
 > of integer methods and an Interface `NumberFormating` providing formatting
 > methods for numbers into strings are likely to be used together.
 > Interface designers should ensure that all the methods in `Calculator` and
-> `NumberFormatting` have a distinct method selector
+> `NumberFormatting` have a distinct method selectors.
 
 
 #### Interface Description
@@ -240,61 +242,62 @@ For example:
 
 ### Contracts
 
-A Contract is the complete set of methods that an app implements. It
-is similar to an interface, but it may include further details about the
+A Contract is a declaration of what an Application implements. It includes
+the complete list of the methods implemented by the related Application.
+It is similar to an Interface, but it may include further details about the
 concrete implementation, as well as implementation-specific methods that
-do not belong to any interface. All methods in a Contract **MUST** be
+do not belong to any Interface. All methods in a Contract **MUST** be
 unique; specifically, each method **MUST** have a unique method selector.
 
 Method names in Contracts **MAY** begin with underscore, but these
-names are reserved for use by this ARC and its future revisions.
+names are reserved for use by this ARC and future extensions of this ARC.
 
 #### OnCompletion Actions and Creation
 
 In addition to the set of methods from the Contract's definition,
-a Contract **MAY** allow application calls with zero arguments, also
-known as bare application calls. Since method invocations with zero
-arguments still encode the method selector as the first application
-call arguments, bare application calls are always distinguishable
+a Contract **MAY** allow Application calls with zero arguments, also
+known as bare Application calls. Since method invocations with zero
+arguments still encode the method selector as the first Application
+call arguments, bare Application calls are always distinguishable
 from method invocations.
 
-The primary purpose of bare application calls is to allow the
+The primary purpose of bare Application calls is to allow the
 execution of an OnCompletion (`apan`) action which requires no
 inputs and has no return value. A Contract **MAY** allow this
 for all OnCompletion actions, for only a subset of them, or for
 none at all. Great care should be taken when allowing these
 operations.
 
-If a Contract elects to allow bare application calls for some
+If a Contract elects to allow bare Application calls for some
 OnCompletion actions, then that Contract **SHOULD** also allow
 any of its methods to be called with those OnCompletion actions,
 as long as this would not cause undesirable or nonsensical behavior.
 
 > The reason for this is because if it's acceptable to allow an
 > OnCompletion action to take place in isolation inside of a bare
-> application call, then it's most likely acceptable to allow
+> Application call, then it's most likely acceptable to allow
 > the same action to take place at the same time as an ABI method
 > call. And since the latter can be accomplished in just one
 > transaction, it can be more efficient.
 
 If a Contract requires an OnCompletion action to take inputs or
 to return a value, then the **RECOMMENDED** behavior of the Contract
-should be to not allow bare application calls for that OnCompletion
+should be to not allow bare Application calls for that OnCompletion
 action. Rather, the Contract should have one or more methods that
 are meant to be called with the appropriate OnCompletion action set
 in order to process that action.
 
-If a Contract is called with greater than zero application call
-arguments (**NOT** a bare application call), the Contract **MUST**
+If an Application is called with greater than zero Application call
+arguments (**NOT** a bare Application call), the Application **MUST**
 always treat the first argument as a method selector and invoke
 the specified method, regardless of the OnCompletion action of
-the application call. This applies to application creation
-transactions as well, where the supplied application ID is 0.
+the Application call. This applies to Application creation
+transactions as well, where the supplied Application ID is 0.
 
 Similar to OnCompletion actions, if a Contract requires its
 creation transaction to take inputs or to return a value, then
 the **RECOMMENDED** behavior of the Contract should be to not
-allow bare application calls for creation. Rather, the Contract
+allow bare Application calls for creation. Rather, the Contract
 should have one or more methods that are meant to be called
 in order to create the Contract.
 
@@ -327,6 +330,12 @@ interface Contract {
 ```
 
 Contract names **MUST** satisfy the regular expression `[_A-Za-z][A-Za-z0-9_]*`.
+
+The `desc` fields of the Contract and the methods inside the Contract 
+**SHOULD** contain the informations that are not explicitely encoded in the other fields,
+such as support of bare Application calls, requirement of specific 
+OnCompletion action for specific methods, and methods to call for creation
+(if creation cannot be done via a bare Application call).
 
 For example:
 
@@ -372,19 +381,19 @@ information should be stored and its format.
 
 ### Standard Format
 
-The method selector must be the first application call argument (index 0),
-accessible as `txna ApplicationArgs 0` from TEAL (except for bare application
+The method selector must be the first Application call argument (index 0),
+accessible as `txna ApplicationArgs 0` from TEAL (except for bare Application
 calls, which use zero application call arguments).
 
 If a method has 15 or fewer arguments, each arguments **MUST** be placed in
-order in the following application call argument slots (indexes 1 through
+order in the following Application call argument slots (indexes 1 through
 15). The arguments **MUST** be encoded as defined in the [Encoding](#encoding)
 section.
 
 Otherwise, if a method has 16 or more arguments, the first 14 **MUST** be
-placed in order in the following application call argument slots (indexes 1
+placed in order in the following Application call argument slots (indexes 1
 through 14), and the remaining arguments **MUST** be encoded as a tuple
-in the final application call argument slot (index 15). The arguments must
+in the final Application call argument slot (index 15). The arguments must
 be encoded as defined in the [Encoding](#encoding) section.
 
 If a method has a non-void return type, then the return value of the method
@@ -401,10 +410,10 @@ bytes of the SHA-512/256 hash of the ASCII string `return`. In hex, this is
 
 ### Implementing a Method
 
-An ARC-4 app implementing a method:
+An ARC-4 Application implementing a method:
 
 1. **MUST** check if `txn NumAppArgs` equals 0. If true, then this is a
-bare application call. If the Contract supports bare application calls
+bare Application call. If the Contract supports bare Application calls
 for the current transaction parameters (it **SHOULD** check the OnCompletion
 action and whether the transaction is creating the application), it **MUST**
 handle the call appropriately and either approve or reject the transaction.
@@ -426,7 +435,7 @@ section. If the method has more than 15 arguments and the contract
 needs to extract an argument beyond the 14th, it **MUST** decode
 `txna ApplicationArgs 15` as a tuple to access the arguments contained in it.
 
-5. If the method is non-void, the application **MUST** encode the
+5. If the method is non-void, the Application **MUST** encode the
 return value as described in the [Encoding](#encoding) section and then
 `log` it with the prefix `151f7c75`. Other values **MAY** be logged
 before the return value, but other values **MUST NOT** be logged after
@@ -435,20 +444,20 @@ the return value.
 
 ### Calling a Method from Off-Chain
 
-To invoke an ARC-4 app, an off-chain system, such as a dapp or wallet,
+To invoke an ARC-4 Application, an off-chain system, such as a dapp or wallet,
 would first obtain the Interface or Contract description JSON object
 for the app. The client may now:
 
-1. Create an application call transaction with the following parameters:
-    1. Use the ID of the desired application whose program code
+1. Create an Application call transaction with the following parameters:
+    1. Use the ID of the desired Application whose program code
        implements the method being invoked, or 0 if they wish to
-       create the application.
+       create the Application.
     2. Use the selector of the method being invoked as the first
-       application call argument.
+       Application call argument.
     3. Encode all arguments for the method, if any, as described in
        the [Encoding](#encoding) section. If the method has more than 15 arguments,
        encode all arguments beyond (but not including) the 14th
-       as a tuple into the final application call argument.
+       as a tuple into the final Application call argument.
 2. Submit this transaction and wait until it successfully commits to
    the blockchain.
 3. Decode the return value, if any, from the ApplyData's log
@@ -457,10 +466,10 @@ for the app. The client may now:
 Clients **MAY** ignore the return value.
 
 An exception to the above instructions is if the app supports bare
-application calls for some transaction parameters, and the client
+Application calls for some transaction parameters, and the client
 wishes to invoke this functionality. Then the client may simply create
-and submit to the network an application call transaction with the ID of
-the application (or 0 if they wish to create the application) and the
+and submit to the network an Application call transaction with the ID of
+the Application (or 0 if they wish to create the application) and the
 desired OnCompletion value set. Application arguments **MUST NOT** be
 present.
 
@@ -572,7 +581,7 @@ further away.)
 * `application` represents an Algorand Smart Contract, stored in the Foreign Apps (`apfa`) array
 
 Some AVM opcodes require specific values to be placed in the "foreign
-arrays" of the application call transaction. These three types allow
+arrays" of the Application call transaction. These three types allow
 methods to describe these requirements. To encode method calls that
 have these types as arguments, the value in question is placed in the
 Accounts (`apat`), Foreign Assets (`apas`), or Foreign Apps (`apfa`)
@@ -581,17 +590,17 @@ in the appropriate array is encoded in the normal location for this
 argument.
 
 Note that the Accounts and Foreign Apps arrays have an implicit value
-at index 0, the Sender of the transaction or the called application,
+at index 0, the Sender of the transaction or the called Application,
 respectively. Therefore, indexes of any additional values begin at 1.
 Additionally, for efficiency, callers of a method that wish to pass the
-transaction Sender as an `account` value or the called application as
+transaction Sender as an `account` value or the called Application as
 an `application` value **SHOULD** use 0 as the index of these values
 and not explicitly add them to Accounts or Foreign Apps arrays.
 
 When passing addresses, ASAs, or apps that are _not_ required to be
 accessed by such opcodes, ARC-4 Contracts **SHOULD** use the base
 types for passing these types: `address` for accounts and `uint64`
-for asset or application IDs.
+for asset or Application IDs.
 
 ### Transaction Types
 
@@ -612,8 +621,8 @@ describe such requirements.
 * `appl` represents an ApplicationCallTx transaction (create/invoke a Smart Contract)
 
 Arguments of these types are encoded as consecutive transactions in
-the same transaction group as the application call, placed in the
-position immediately preceding the application call. Unlike "foreign"
+the same transaction group as the Application call, placed in the
+position immediately preceding the Application call. Unlike "foreign"
 references, these special types are not encoded in ApplicationArgs as
 small integers "pointing" to the associated object.  In fact, they
 occupy no space at all in the Application Call transaction
@@ -627,22 +636,22 @@ For example, to invoke the method `deposit(string,axfer,pay,uint32)void`,
 a client would create a transaction group containing, in this order:
 1. an asset transfer
 2. a payment
-3. the actual application call
+3. the actual Application call
 
 When encoding the other (non-transaction) arguments, the client 
 **MUST** act as if the transaction arguments were completely absent 
-from the method signature. The application call would contain the method 
+from the method signature. The Application call would contain the method 
 selector in ApplicationArgs[0], the first (string) argument in 
 ApplicationArgs[1], and the fourth (uint32) argument in ApplicationArgs[2].
 
 
-ARC-4 Apps **SHOULD** be constructed to allow their invocations to be
+ARC-4 Applications **SHOULD** be constructed to allow their invocations to be
 combined with other contract invocations in a single atomic group if
 they can do so safely. For example, they **SHOULD** use `gtxns` to examine
 the previous index in the group for a required `pay` transaction,
 rather than hardcode an index with `gtxn`.
 
-In general, an ARC-4 app method with n transactions as arguments **SHOULD** 
+In general, an ARC-4 Application method with n transactions as arguments **SHOULD** 
 only inspect the n previous transactions. In particular, it **SHOULD NOT**
 inspect transactions after and it **SHOULD NOT** check the size of a transaction 
 group (if this can be done safely). 


### PR DESCRIPTION
Change ABI to last call.

Handling
https://github.com/algorandfoundation/ARCs/pull/55#discussion_r768239652:
Reduced terminology to "Application", "Contract", "Interface". No more
"smart contracts" to indicate Algorand Applications.

Change "future revisions" to "future ABI-related ARC" as if we follow
Ethereum EIP, only ARC-0 should be living and have revisions.

One question after this pass:
Why prefixing the return log value?
Is the caller supposed to check the prefix?