### PR TITLE
Fix incorrect capitalization for arc filename refs

### DIFF
--- a/ARCs/arc-0005.md
+++ b/ARCs/arc-0005.md
@@ -8,7 +8,7 @@ status: Draft
 
 > This API is a draft.
 > Some elements may change.
-> This ARC is intended to be completely compatible with [ARC-0001](ARC-0001.md).
+> This ARC is intended to be completely compatible with [ARC-0001](arc-0001.md).
 
 ## Summary
 

--- a/ARCs/arc-0006.md
+++ b/ARCs/arc-0006.md
@@ -16,7 +16,7 @@ An API for a function used to discover the addresses a wallet user is willing to
 ## Abstract
 
 A function, `enable`, which allows the discovery of accounts. 
-This document requires nothing else, but further semantic meaning is prescribed to `enable` in [ARC-0010](ARC-0010.md) which builds off of this one and a few others.
+This document requires nothing else, but further semantic meaning is prescribed to `enable` in [ARC-0010](arc-0010.md) which builds off of this one and a few others.
 The caller of this function is usually a dApp.
 
 ## Specification
@@ -63,13 +63,13 @@ A `GenesisHash` is base64 string representing a 32-byte genesis hash.
 
 ### String specification: `AlgorandAddress`
 
-Defined as in [ARC-0001](ARC-0001.md):
+Defined as in [ARC-0001](arc-0001.md):
 
 > An Algorand address is represented by a 58-character base32 string. It includes includes the checksum.
 
 ### Error Standards
 
-`EnableError` follows the same rules as `SignTxnsError` from [ARC-0001](ARC-0001.md) and uses the same status error codes.
+`EnableError` follows the same rules as `SignTxnsError` from [ARC-0001](arc-0001.md) and uses the same status error codes.
 
 
 ### Semantic requirements

--- a/ARCs/arc-0007.md
+++ b/ARCs/arc-0007.md
@@ -54,7 +54,7 @@ A `PostTxnsFunction` with input argument `stxns:string[]` and promised return va
 
 ### String specification: `SignedTxnStr`
 
-Defined as in [ARC-0001](ARC-0001.md):
+Defined as in [ARC-0001](arc-0001.md):
 
 > [`SignedTxnStr` is] the base64 encoding of the canonical msgpack encoding of the `SignedTxn` corresponding object, as defined in the [Algorand specs](https://github.com/algorandfoundation/specs).
 
@@ -64,7 +64,7 @@ A `TxnId` is a 52-character base32 string (without padding) corresponding to a 3
 
 ### Error standard
 
-`PostTxnsError` follows the same rules as `SignTxnsError` from [ARC-0001](ARC-0001.md) and uses the same status codes as well as the following status codes:
+`PostTxnsError` follows the same rules as `SignTxnsError` from [ARC-0001](arc-0001.md) and uses the same status codes as well as the following status codes:
 
 
 | Status Code | Name | Description |
@@ -87,7 +87,7 @@ Regarding a call to `postTxns(stxns)` with promised return value `ret`:
   > TODO: Decide whether to add an optional flag to not wait for that.
 * If successful, `postTxns` **MUST** resolve the returned promise with the list of transaction IDs `txnIds` of the posted transactions `stxn`.
 * If unsuccessful, `postTxns` **MUST** reject the promise with an error `err` of type `PostTxnsError` such that:
-  * `err.code=4400` if there was a failure sending the transactions or a code as specified in [ARC-0001](ARC-0001.md) if the user or function disallowed posting the transactions.
+  * `err.code=4400` if there was a failure sending the transactions or a code as specified in [ARC-0001](arc-0001.md) if the user or function disallowed posting the transactions.
   * `err.message` **SHOULD** describe what went wrong in as much detail as possible.
   * `err.successTxnIds` **MUST** be an array such that `err.successTxnId[i]` is the transaction ID of `stxns[i]` if `stxns[i]` was succesfully committed to the blockchain, and `null` otherwise.
 


### PR DESCRIPTION
Some references to other arc files returned a 404 on GitHub due to incorrect capitalization of arc filenames.