### PR TITLE
ARC for standardizing traits (attributes) in token metadata

### DIFF
--- a/ARCs/arc-0016.md
+++ b/ARCs/arc-0016.md
@@ -16,7 +16,7 @@ This document introduces the standard for declaring traits (attributes) inside a
 
 ## Abstract
 
-The goal is to establish a standard for traits are declared inside a non-fungible ASA's (NFT) metadata.
+The goal is to establish a standard for how traits are declared inside a non-fungible ASA's (NFT) metadata.
 
 ## Specification
 

--- a/ARCs/arc-0016.md
+++ b/ARCs/arc-0016.md
@@ -84,7 +84,7 @@ The JSON schema for `traits` is as follows:
 ## Rationale
 
 This propoal is to standard how traits are structured for NFT's on Algorand.
-A standard is needed for traits so programs know what to expect in order to calculate things rarity.
+A standard is needed for traits so programs know what to expect in order to calculate things like rarity.
 
 ## Copyright
 

--- a/ARCs/arc-0016.md
+++ b/ARCs/arc-0016.md
@@ -1,0 +1,91 @@
+---
+title: Algorand standard for declaring traits in an ASA's metadata
+description: This is a standard for declaring traits (attributes) in an ASA's metadata.
+author: Keegan Thompson @keeganthomp
+status: Draft
+type: Standards Track
+category: ARC
+created: 2022-01-04
+---
+
+# Standard for declaring traits inside non-fungible Algorand Standard Asset's
+
+## Summary
+
+This document introduces the standard for declaring traits (attributes) inside a non-fungible ASA's (NFT) metadata.
+
+## Abstract
+
+The goal is to establish a standard for traits are declared inside a non-fungible ASA's (NFT) metadata.
+
+## Specification
+
+The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in [RFC-2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+> Comments like this are non-normative.
+
+If the property `traits` is provided anywhere in the metadata of an asset, it **MUST** follow the below schema.
+If the asset is a part of a larger collection and that collection has traits, all the available traits for the collection **MUST** be listed as a property of the `traits` object.
+If the asset does not have a particular trait, it's value **MUST** be "none".
+
+The JSON schema for `traits` is as follows:
+
+```json
+{
+  "title": "Traits for Non-Fungible Token",
+  "type": "object",
+  "properties": {
+    "traits": {
+      "type": "object",
+      "description": "Traits (attributes) that can be used to calculate things like rarity. Values may be strings or numbers"
+    }
+  }
+}
+```
+
+#### Examples
+
+##### Example of an NFT that has traits
+
+```json
+{
+  "name": "NFT With Traits",
+  "description": "NFT with traits",
+  "image": "https://s3.amazonaws.com/your-bucket/images/two.png",
+  "image_integrity": "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+  "properties": {
+    "creator": "Tim Smith",
+    "created_at": "January 2, 2022",
+    "traits": {
+      "background": "red",
+      "shirt_color": "blue",
+      "glasses": "none",
+      "tattoos": 4,
+    }
+  }
+}
+```
+
+##### Example of an NFT that has no traits
+
+```json
+{
+  "name": "NFT Without Traits",
+  "description": "NFT without traits",
+  "image": "https://s3.amazonaws.com/your-bucket/images/one.png",
+  "image_integrity": "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+  "properties": {
+    "creator": "John Smith",
+    "created_at": "January 1, 2022",
+  }
+}
+```
+
+## Rationale
+
+This propoal is to standard how traits are structured for NFT's on Algorand.
+A standard is needed for traits so programs know what to expect in order to calculate things rarity.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/ARCs/arc-0016.md
+++ b/ARCs/arc-0016.md
@@ -8,7 +8,7 @@ category: ARC
 created: 2022-01-04
 ---
 
-# Standard for declaring traits inside non-fungible Algorand Standard Asset's
+# Standard for declaring traits inside non-fungible ASA's metadata
 
 ## Summary
 

--- a/ARCs/arc-0016.md
+++ b/ARCs/arc-0016.md
@@ -83,7 +83,7 @@ The JSON schema for `traits` is as follows:
 
 ## Rationale
 
-This propoal is to standard how traits are structured for NFT's on Algorand.
+This propoal is to standardize how traits (attributes) are structured for NFT's on Algorand.
 A standard is needed for traits so programs know what to expect in order to calculate things like rarity.
 
 ## Copyright

--- a/ARCs/arc-0016.md
+++ b/ARCs/arc-0016.md
@@ -16,7 +16,7 @@ This document introduces the standard for declaring traits (attributes) inside a
 
 ## Abstract
 
-The goal is to establish a standard for how traits are declared inside a non-fungible ASA's (NFT) metadata.
+The goal is to establish a standard for how traits are declared inside a non-fungible ASA's (NFT) metadata, for example as specified in ARC-3 or ARC-69.
 
 ## Specification
 
@@ -24,7 +24,7 @@ The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL 
 
 > Comments like this are non-normative.
 
-If the property `traits` is provided anywhere in the metadata of an asset, it **MUST** follow the below schema.
+If the property `traits` is provided anywhere in the metadata of an asset, it **MUST** adhere to the schema below.
 If the asset is a part of a larger collection and that collection has traits, all the available traits for the collection **MUST** be listed as a property of the `traits` object.
 If the asset does not have a particular trait, it's value **MUST** be "none".
 
@@ -83,8 +83,7 @@ The JSON schema for `traits` is as follows:
 
 ## Rationale
 
-This propoal is to standardize how traits (attributes) are structured for NFT's on Algorand.
-A standard is needed for traits so programs know what to expect in order to calculate things like rarity.
+A standard for traits is needed so programs know what to expect in order to calculate things like rarity.
 
 ## Copyright
 


### PR DESCRIPTION
Establishes a standard for how to declare an NFT's traits inside a token's metadata.