### PR TITLE
ARC-0004: fix typos

### DIFF
--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -79,7 +79,7 @@ A method signature is a unique identifier for a method. The signature
 is a string that consists of the method's name, an open parenthesis, a
 comma-separated list of the types of its arguments, a closing
 parenthesis, and the method's return type, or `void` if it does not
-return a value. The names of arguments **MUST NOT** included in a
+return a value. The name of arguments **MUST NOT** be included in a
 method's signature, and **MUST NOT** contain any whitespace.
 
 For example, `add(uint64,uint64)uint128` is the method signature for a
@@ -132,20 +132,20 @@ The JSON structure for such an object is:
 ```typescript
 interface Method {
   /** The name of the method */
-  name: string,
+  name: string;
   /** Optional, user-friendly description for the method */
-  desc?: string,
+  desc?: string;
   /** The arguments of the method, in order */
   args: Array<{
     /** The type of the argument */
-    type: string,
+    type: string;
     /** Optional, user-friendly name for the argument */
-    name?: string,
+    name?: string;
     /** Optional, user-friendly description for the argument */
-    desc?: string
-  }>,
+    desc?: string;
+  }>;
   /** Information about the method's return value */
-  returns: { type: string, desc?: string }
+  returns: { type: string; desc?: string };
 }
 ```
 
@@ -175,7 +175,7 @@ A smart contract *implements* an Interface if it supports
 all of the methods from that Interface. A smart contract **MAY** implement
 zero, one, or multiple Interfaces.
 
-Interfaces designer **SHOULD** try to prevent collisions of method selectors 
+Interface designers **SHOULD** try to prevent collisions of method selectors 
 between Interfaces that are likely to be implemented together by the same 
 application.
 
@@ -196,11 +196,11 @@ The JSON structure for such an object is:
 ```typescript
 interface Interface {
   /** A user-friendly name for the interface */
-  name: string,
+  name: string;
   /** Optional, user-friendly description for the interface */
-  desc?: string,
+  desc?: string;
   /** All of the methods that the interface contains */
-  methods: Method[]
+  methods: Method[];
 }
 ```
 
@@ -562,8 +562,8 @@ encoding these types are covered above.
 ### Reference Types
 
 Three special types are supported _only_ as the type of an
-argument. They **MUST NOT* be embedded in arrays or tuples, as 
-their encoding is unusual. (They **MAY** implicitely be part of
+argument. They **MUST NOT** be embedded in arrays or tuples, as 
+their encoding is unusual. (They **MAY** implicitly be part of
 a tuple if they are the type of the 15-th argument or an argument
 further away.)
 
@@ -642,8 +642,8 @@ they can do so safely. For example, they **SHOULD** use `gtxns` to examine
 the previous index in the group for a required `pay` transaction,
 rather than hardcode an index with `gtxn`.
 
-In general, an ARC-4 app method with n transactions as arguments **SHOULD** 
-only inspect the n previous transactions. In particular, it **SHOULD NOT**
+In general, an ARC-4 app method with `n` transactions as arguments **SHOULD** 
+only inspect the `n` previous transactions. In particular, it **SHOULD NOT**
 inspect transactions after and it **SHOULD NOT** check the size of a transaction 
 group (if this can be done safely). 
 In addition, a given method **SHOULD** always expect the same


### PR DESCRIPTION
Saw some typos while reading it.

For the commas -> semicolons, my prettier plugin was complaining about it so I also committed the change.