### PR TITLE
Extend arc-6 with enableNetwork and enableAccounts

### DIFF
--- a/ARCs/arc-0006.md
+++ b/ARCs/arc-0006.md
@@ -11,12 +11,13 @@ status: Draft
 
 ## Summary
 
-An API for a function used to discover the addresses a wallet user is willing to use for a given Algorand DApp.
+An API for a function used to discover the addresses a wallet user is willing to use for a given Algorand DApp, and the network on which the user is willing to use them.
 
 ## Abstract
 
-A function, `enable`, which allows the discovery of accounts. 
-This document requires nothing else, but further semantic meaning is prescribed to `enable` in [ARC-0010](arc-0010.md) which builds off of this one and a few others.
+A function, `enable`, which allows the discovery of accounts.
+Optional functions, `enableNetwork` and `enableAccounts`, which handle the multiple capabilities of `enable` separately.
+This document requires nothing else, but further semantic meaning is prescribed to these functions in [ARC-0010](arc-0010.md) which builds off of this one and a few others.
 The caller of this function is usually a dApp.
 
 ## Specification
@@ -31,21 +32,43 @@ The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL 
 export type AlgorandAddress = string;
 export type GenesisHash = string;
 
+export type EnableNetworkFunction = (
+  opts?: EnableNetworkOpts
+) => Promise<EnableNetworkResult>;
+
+export type EnableAccountsFunction = (
+  opts?: EnableAccountsOpts
+) => Promise<EnableAccountsResult>;
+
 export type EnableFunction = (
   opts?: EnableOpts
 ) => Promise<EnableResult>;
 
-export interface EnableOpts = {
+export interface EnableNetworkOpts = {
   genesisID?: string;
   genesisHash?: GenesisHash;
-  accounts?: AlgorandAddress[];
-}
+};
 
-export interface EnableResult = {
+export interface EnableAccountsOpts = {
+  accounts?: AlgorandAddress[];
+};
+
+export type EnableOpts = (
+  EnableNetworkOpts & EnableAccountsOpts
+);
+
+export interface EnableNetworkResult = {
   genesisID: string;
   genesisHash: GenesisHash;
+}
+
+export interface EnableAccountsResult = {
   accounts: AlgorandAddress[];
 }
+
+export type EnableResult = (
+  EnablNetworkResult & EnableAccountsResult
+);
 
 export interface EnableError extends Error {
   code: number;
@@ -140,6 +163,10 @@ The caller **MUST NOT** assume that the `enable` function will return always the
 For example, a user may want to change network or accounts for a dApp.
 That is why, upon refresh, the dApp **SHOULD** automatically switch network and perform all required changes.
 Examples of required changes include but are not limited to change of the list of accounts, change of statuses of the account (e.g., opted in or not), change of the balances of the accounts. 
+
+## `enableNetwork` and `enableAccounts`
+
+It may be desirable for a dapp to perform network queries prior to requesting that the user enable an account for use with the dapp. Wallets may provide the functionality of `enable` in two parts: `enableNetwork` for network discovery, and `enableAccounts` for account discovery, which together are the equivalent of calling `enable`.
 
 ## Rationale
 

--- a/ARCs/arc-0010.md
+++ b/ARCs/arc-0010.md
@@ -16,7 +16,10 @@ An amalgamation of APIs which comprise the minimum requirements for Reach to be 
 ## Abstract
 
 A group of related functions:
+
 * `enable` (**REQUIRED**)
+* `enableNetwork` (**OPTIONAL**)
+* `enableAccounts` (**OPTIONAL**)
 * `signAndPostTxns` (**REQUIRED**)
 * `getAlgodv2Client` (**REQUIRED**)
 * `getIndexerClient` (**REQUIRED**)
@@ -25,7 +28,7 @@ A group of related functions:
 
 ## Specification
 
-* `enable`: as specified in [ARC-0006](arc-0006.md).
+* `enable`, `enableNetwork`, and `enableAccounts`: as specified in [ARC-0006](arc-0006.md).
 * `signAndPostTxns`: as specified in [ARC-0008](arc-0008.md).
 * `getAlgodv2Client` and `getIndexerClient`: as specified in [ARC-0009](arc-0009.md).
 * `signTxns`: as specified in [ARC-0005](arc-0005.md) / [ARC-0001](arc-0001.md).
@@ -36,9 +39,11 @@ There are additional semantics for using these functions together.
 ### Semantic Requirements
 
 * `enable` **SHOULD** be called before calling the other functions and upon refresh of the dApp.
-* If `signAndPostTxns`, `getAlgodv2Client`, `getIndexerClient`, `signTxns`, or `postTxns` are called before `enable`, they **SHOULD** throw an error object with property `code=4202`. (See Error Standards in [ARC-0001](arc-0001.md)).
-* `getAlgodv2Client` and `getIndexerClient` **MUST** return connections to the network indicated by the `network` result of `enable`.
-* `signAndPostTxns` **MUST** post transactions to the network indicated by the `network` result of `enable`
+* Calling `enableNetwork` and then `enableAccounts` **MUST** be equivalent to calling `enable`.
+* If used instead of `enable`: `enableNetwork` **SHOULD** be called before `enableAccounts` and `getIndexerClient`. Both `enableNetwork` and `enableAccounts` **SHOULD** be called before the other functions.
+* If `signAndPostTxns`, `getAlgodv2Client`, `getIndexerClient`, `signTxns`, or `postTxns` are called before `enable` (or `enableAccounts`), they **SHOULD** throw an error object with property `code=4202`. (See Error Standards in [ARC-0001](arc-0001.md)).
+* `getAlgodv2Client` and `getIndexerClient` **MUST** return connections to the network indicated by the `network` result of `enable` (or `enableNetwork`).
+* `signAndPostTxns` **MUST** post transactions to the network indicated by the `network` result of `enable` (or `enableNetwork`)
 * The result of `getAlgodv2Client` **SHOULD** only be used to query the network. `postTxns` (if available) and `signAndPostTxns` **SHOULD** be used to send transactions to the network. The `Algodv2Client` object **MAY** be modified to throw exceptions if the caller tries to use it to post transactions.
 * `signTxns` and `postTxns` **MAY** or **MAY NOT** be provided. When one is provided, they both **MUST** be provided. In addition, `signTxns` **MAY** display a warning that the transactions are returned to the dApp rather than posted directly to the blockchain.
 
@@ -79,11 +84,11 @@ However, there are cases where `signTxns` and `postTxns` need to be used: for ex
 async function main(wallet) {
 
   // Account discovery
-  const enabled = await wallet.enable({network: 'testnet-v1.0'});
+  const enabled = await wallet.enable({genesisID: 'testnet-v1.0'});
   const from = enabled.accounts[0];
 
   // Querying
-  const algodv2 = new algosdk.Algodv2(await wallet.getAlgodv2());
+  const algodv2 = new algosdk.Algodv2(await wallet.getAlgodv2Client());
   const suggestedParams = await algodv2.getTransactionParams().do();
   const txns = makeTxns(from, suggestedParams);
 

--- a/ARCs/arc-0011.md
+++ b/ARCs/arc-0011.md
@@ -22,6 +22,8 @@ A property `algorand` attached to the `window` browser object, with all the feat
 ```ts
 interface WindowAlgorand {
   enable: EnableFunction;
+  enableNetwork?: EnableNetworkFunction;
+  enableAccounts?: EnableAccountsFunction;
   signAndPostTxns: SignAndPostTxnsFunction;
   getAlgodv2Client: GetAlgodv2ClientFunction;
   getIndexerClient: GetIndexerClientFunction;


### PR DESCRIPTION
At Reach we have found it useful to split `enable` into `enableNetwork` and `enableAccounts` so that network queries can be performed without asking the user to select an account. We propose that this be included as optional in arcs 6, 10, and 11.