### PR TITLE
ARC-4: Remove constraints on reference types

### DIFF
--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -520,7 +520,7 @@ any leading zeros, _unless_ `N` is zero, in which case only a single 0 character
 * `<type>[]`: A variable-length array. `type` can be any other type.
 * `string`: A variable-length byte array (`byte[]`) assumed to contain UTF-8 encoded content.
 * `(T1,T2,…,TN)`: A tuple of the types `T1`, `T2`, …, `TN`, `N >= 0`.
-* reference types `account`, `asset`, `application`: only for arguments, in which case they are an
+* reference types `account`, `asset`, `application`: For encoding purposes they are an
 alias for `uint8`. See section "Reference Types" below.
 
 Additional special use types are defined in [Reference Types](#reference-types)
@@ -581,17 +581,12 @@ For any ABI value `x`, we recursively define `enc(x)` to be as follows:
 * If `x` is a boolean value `bool`:
     * `enc(x)` is a single byte whose **most significant bit** is either 1 or 0, if `x` is true or false respectively. All other bits are 0. Note: this means that a value of true will be encoded as `0x80` (`10000000` in binary) and a value of false will be encoded as `0x00`. This is in contrast to most other encoding schemes, where a value of true is encoded as `0x01`.
 
-Since `string` and `address` are aliases for `byte[]` and `byte[32]`
-respectively (and `byte` is an alias for `uint8`), the rules for
-encoding these types are covered above.
+Other aliased types' encodings are already covered:
+- `string` and `address` are aliases for `byte[]` and `byte[32]` respectively
+- `byte` is an alias for `uint8`
+- each of the reference types is an alias for `uint8`
 
 ### Reference Types
-
-Three special types are supported _only_ as the type of an
-argument. They **MUST NOT** be embedded in arrays or tuples, as 
-their encoding is unusual. (They **MAY** implicitly be part of
-a tuple if they are the type of the 15-th argument or an argument
-further away.)
 
 * `account` represents an Algorand account, stored in the Accounts (`apat`) array
 * `asset` represents an Algorand Standard Asset (ASA), stored in the Foreign Assets (`apas`) array

--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -520,8 +520,8 @@ any leading zeros, _unless_ `N` is zero, in which case only a single 0 character
 * `<type>[]`: A variable-length array. `type` can be any other type.
 * `string`: A variable-length byte array (`byte[]`) assumed to contain UTF-8 encoded content.
 * `(T1,T2,…,TN)`: A tuple of the types `T1`, `T2`, …, `TN`, `N >= 0`.
-* reference types `account`, `asset`, `application`: For encoding purposes they are an
-alias for `uint8`. See section "Reference Types" below.
+* reference types `account`, `asset`, `application`: **MUST NOT** be used as the return type.
+For encoding purposes they are an alias for `uint8`. See section "Reference Types" below.
 
 Additional special use types are defined in [Reference Types](#reference-types)
 and [Transaction Types](#transaction-types).
@@ -587,6 +587,9 @@ Other aliased types' encodings are already covered:
 - each of the reference types is an alias for `uint8`
 
 ### Reference Types
+
+Three special types are supported _only_ as the type of an argument.
+They _can_ be embedded in arrays and tuples.
 
 * `account` represents an Algorand account, stored in the Accounts (`apat`) array
 * `asset` represents an Algorand Standard Asset (ASA), stored in the Foreign Assets (`apas`) array


### PR DESCRIPTION
With this change it will be possible to create flexible ABI-compliant interfaces without resolving to dirty hacks.

Example use-cases in which this change is handy:
- `optin(asset[])void`
- `distributerewards((account,uint64)[])void` - or any batch operation

In my opinion, such methods are useful and are likely to be used by application creators. Their current incompatibility with the ABI will result in non-standardized approaches being taken.