### PR TITLE
Update arc-0001.md

### DIFF
--- a/ARCs/arc-0001.md
+++ b/ARCs/arc-0001.md
@@ -240,7 +240,7 @@ The call `signTxns(txns, opts)` **MUST** either throws an error or return an arr
 
 1. If `txns[i].signers` is an empty array, the wallet **MUST NOT** sign the transaction `txns[i]`, and: 
   * if `txns[i].stxn` is not present, `ret[i]` **MUST** be set to `null`.
-  * if `txns[i].stxn` is present and is a valid `SignedTxn` with inner transaction exactly matching `txns[i].txn`, `ret[i]` **MUST**  be set to `txns[i].stxn`. (See section on the semantic of `WalletTransaction` for the exact requirements on `txns[i].stxn`.)
+  * if `txns[i].stxn` is present and is a valid `SignedTxn` with the underlying transaction exactly matching `txns[i].txn`, `ret[i]` **MUST**  be set to `txns[i].stxn`. (See section on the semantic of `WalletTransaction` for the exact requirements on `txns[i].stxn`.)
   * otherwise, the wallet **MUST** throw a `4300` error.
 2. Otherwise, the wallet **MUST** sign the transaction `txns[i].txn` and `ret[i]` **MUST** be set to the base64 encoding of the canonical msgpack encoding of the `SignedTxn` corresponding object, as defined in the [Algorand specs](https://github.com/algorandfoundation/specs). For Algorand version 2.5.5, see the [authorization and signatures Section](https://github.com/algorandfoundation/specs/blob/d050b3cade6d5c664df8bd729bf219f179812595/dev/ledger.md#authorization-and-signatures) of the specs or the [Go structure](https://github.com/algorand/go-algorand/blob/304815d00b9512cf9f91dbb987fead35894676f4/data/transactions/signedtxn.go#L31).
 


### PR DESCRIPTION
replace `inner transaction` with `underlying transaction` to prevent confusion with AVM inner-transactions