### PR TITLE
Update arc-0007.md to support transaction groups with only 1 transaction

### DIFF
--- a/ARCs/arc-0007.md
+++ b/ARCs/arc-0007.md
@@ -76,7 +76,8 @@ A `TxnId` is a 52-character base32 string (without padding) corresponding to a 3
 Regarding a call to `postTxns(stxns)` with promised return value `ret`:
 
 * `postTxns` **MAY** assume that `stxns` is an array of valid `SignedTxnStr` strings that represent correctly signed transactions such that:
-  * Either all transaction belong to the same group of transactions and are in the correct order. In other words, either `stxns` is an array of a single transaction with a zero group ID (`txn.Group`), or `stxns` is an array of more than one transactions with the *same* non-zero group ID. The function **MUST** reject if the transactions do not match their group ID. (The caller must provide the transactions in the order defined by the group ID.)
+  * Either all transaction belong to the same group of transactions and are in the correct order. In other words, either `stxns` is an array of a single transaction with a zero group ID (`txn.Group`), or `stxns` is an array of one or more transactions with the *same* non-zero group ID. The function **MUST** reject if the transactions do not match their group ID. (The caller must provide the transactions in the order defined by the group ID.)
+  >An early draft of this ARC required that the size of a group of transactions must be greater than 1 but, since the Algorand protocol supports groups of size 1, this requirement had been changed so dApps don't have to have special cases for single transactions and can always send a group to the wallet.
   * Or `stxns` is a concatenation of arrays satisfying the above.
 * `postTxns` **MUST** attempt to post all transactions together.  With the `algod` v2 API, this implies splitting the transactins into groups and making an API call per transaction group. `postTxns` **SHOULD NOT** wait after each transaction group but post all of them without pause in-between.
 * `postTxns` **MAY** ask the user whether they are approve posting those transactions.


### PR DESCRIPTION
this way dApps don't have to have special cases for single transactions and can always send a group to the wallet.