### PR TITLE
Attach discussions

### DIFF
--- a/ARCs/arc-0001.md
+++ b/ARCs/arc-0001.md
@@ -2,6 +2,7 @@
 arc: 1
 title: Algorand Wallet Transaction Signing API
 status: Draft
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/1
 ---
 
 # Algorand Wallet Transaction Signing API

--- a/ARCs/arc-0002.md
+++ b/ARCs/arc-0002.md
@@ -2,6 +2,7 @@
 arc: 2
 title: Algorand Transaction Note Field Conventions
 status: Draft
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/2
 ---
 
 # Algorand Transaction Note Field Conventions

--- a/ARCs/arc-0003.md
+++ b/ARCs/arc-0003.md
@@ -2,6 +2,7 @@
 arc: 3
 title: Algorand Standard Asset Parameters Conventions for Fungible and Non-Fungible Tokens
 status: Final
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/3
 ---
 
 # Algorand Standard Asset Parameters Conventions for Fungible and Non-Fungible Tokens

--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -2,6 +2,7 @@
 arc: 4
 title: Algorand Application Binary Interface (ABI)
 status: Last Call
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/44
 ---
 
 # Algorand Transaction Calling Conventions

--- a/ARCs/arc-0005.md
+++ b/ARCs/arc-0005.md
@@ -2,6 +2,7 @@
 arc: 5
 title: Algorand Wallet Transaction Signing API (Functionality Only)
 status: Draft
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/52
 ---
 
 # Algorand Wallet Transaction Signing API (Functionality Only)

--- a/ARCs/arc-0006.md
+++ b/ARCs/arc-0006.md
@@ -2,6 +2,7 @@
 arc: 6
 title: Algorand Wallet Address Discovery API
 status: Draft
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/52
 ---
 
 # Algorand Wallet Address Discovery API

--- a/ARCs/arc-0007.md
+++ b/ARCs/arc-0007.md
@@ -2,6 +2,7 @@
 arc: 7
 title: Algorand Wallet Post Transactions API
 status: Draft
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/52
 ---
 
 # Algorand Wallet Post Transactions API

--- a/ARCs/arc-0008.md
+++ b/ARCs/arc-0008.md
@@ -2,6 +2,7 @@
 arc: 8
 title: Algorand Wallet Sign and Post API
 status: Draft
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/52
 ---
 
 # Algorand Wallet Sign and Post API

--- a/ARCs/arc-0009.md
+++ b/ARCs/arc-0009.md
@@ -2,6 +2,7 @@
 arc: 9
 title: Algorand Wallet Algodv2 and Indexer API
 status: Draft
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/52
 ---
 
 # Algorand Wallet Algodv2 and Indexer API

--- a/ARCs/arc-0010.md
+++ b/ARCs/arc-0010.md
@@ -2,6 +2,7 @@
 arc: 10
 title: Algorand Wallet Reach Minimum Requirements
 status: Draft
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/52
 ---
 
 # Algorand Wallet Reach Minimum Requirements

--- a/ARCs/arc-0011.md
+++ b/ARCs/arc-0011.md
@@ -2,6 +2,7 @@
 arc: 11
 title: Algorand Wallet Reach Browser Spec
 status: Draft
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/52
 ---
 
 # Algorand Wallet Reach Browser Spec

--- a/ARCs/arc-0019.md
+++ b/ARCs/arc-0019.md
@@ -3,7 +3,7 @@ arc: 19
 title: Templating of NFT ASA URLs for mutability
 description: A proposal to allow a templating mechanism of the URL so that changeable data in an asset can be substituted by a client, providing a mutable URL.
 author: Patrick Bennett / TxnLab Inc. (@pbennett)
-discussions-to: #arcs in Algorand Discord
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/73
 status: Draft
 type: Standards Track
 category: ARC


### PR DESCRIPTION
Attaching discussion links to ARCs by adding the `discussions-to` attribute to the header of each ARC.
This will allow presenting those links in the github page.