### PR TITLE
Moving ARC19 status to Final.

### DIFF
--- a/ARCs/arc-0019.md
+++ b/ARCs/arc-0019.md
@@ -4,7 +4,7 @@ title: Templating of NFT ASA URLs for mutability
 description: A proposal to allow a templating mechanism of the URL so that changeable data in an asset can be substituted by a client, providing a mutable URL.
 author: Patrick Bennett / TxnLab Inc. (@pbennett)
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/73
-status: Draft
+status: Final
 type: Standards Track
 category: ARC
 created: 2021-01-23


### PR DESCRIPTION
ARC19 should realistically be considered final at this point as almost 14K ARC19 NFTs have already been minted - all completely immutable.  
Any changes to the URL spec of ARC19 at this point will likely need to be an independent ARC.