### PR TITLE
ARC-0004: Specify encoding for variable array length

### DIFF
--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -574,7 +574,7 @@ For any ABI value `x`, we recursively define `enc(x)` to be as follows:
 * If `x` is a fixed-length array `T[N]`:
     * `enc(x) = enc((x[0], ..., x[N-1]))`, i.e. it’s encoded as if it were an `N` element tuple where every element is type `T`.
 * If `x` is a variable-length array `T[]` with `k` elements:
-    * `enc(x) = enc(k) enc([x[0], ..., x[k-1]])`, i.e. it’s encoded as if it were a fixed-length array of `k` elements, prefixed with its length, `k`.
+    * `enc(x) = enc(k) enc([x[0], ..., x[k-1]])`, i.e. it’s encoded as if it were a fixed-length array of `k` elements, prefixed with its length, `k` encoded as a `uint16`.
 * If `x` is an `N`-bit unsigned integer, `uint<N>`:
     * `enc(x)` is the `N`-bit big-endian encoding of `x`.
 * If `x` is an `N`-bit unsigned fixed-point decimal number with precision `M`, `ufixed<N>x<M>`:


### PR DESCRIPTION
The encoding for `k`, which specifies the length of a variable length array was not specified. Talking to @barnjamin this value should be encoded as uint16. This PR specifies that. 