### PR TITLE
ARC-0029: Soul Bound NFTs

### DIFF
--- a/ARCs/arc-0029.md
+++ b/ARCs/arc-0029.md
@@ -1,0 +1,102 @@
+---
+arc: 0029
+title: Algorand Standard Asset Parameters Conventions for Soul Bound NFTs
+author:
+- Lukas Kotol (@hathoriel)
+  discussions-to: https://github.com/algorandfoundation/ARCs/pull/117
+  status: Draft
+  created: 2022-08-06
+---
+
+## Summary
+
+This document introduces conventions for the parameters of Algorand Standard Assets (ASAs) for Soul Bound non-fungible tokens (NFTs).
+
+## Abstract
+
+A "Soul Bound NFT" is an Algorand Standard Asset (ASA) defined by configuration of parameters preventing
+them to be transferred from an original address.
+
+## Motivation
+Non-fungible tokens (NFTs) are digital tokens on the blockchain network.
+Each NFT has its unique token ID. This is just a number that identifies the token,
+and no two NFTs minted from the same smart contract can have the same token ID.
+This proves that every NFT is unique. NFTs can be traded or given away, which
+means that they are not irreversibly tied to only one entity.
+
+But imagine one who wants after completing a challenge to get honour or
+status which is bounded to the person and certifying such a person has finished the challenge.
+This scenario can be mapped to real-life achievements like obtaining a university degree,
+winning a club competition or earning a professional certification.
+
+Described use cases are also widely used in gaming.
+In some MMORPG games, after slaying rare monsters, game characters get legendary items
+which are bounded only to the hero who took part in monster destruction.
+These legendary items are characterized by the fact that they cannot be sold
+or traded with other players, which means they are "Soul Bounded" to the game character.
+The consequence of binding items to the character is that other players could be sure their
+owner had slain such a monster and it can give the slayer special status among other players.
+Once players dont want to keep "Soul Bounded" items, they can trash them to permanently remove them from their account.
+
+However, the ASA lacks the possibility of proving that the owner of the address finished some task, mission or job,
+because the ASA can be transferred between addresses.
+
+The Soul Bound NFTs defined by this ARC prevent ASA to be transferred and permanently binding NFTs to the owner's address.
+This means that not only user cannot transfer ownership, but the minter also cannot withdraw/transfer/change ownership as well.
+By introducing this as a standard users can confidently and consistently prove or certify
+that a project, competition or event has been completed by themselves.
+
+## Specification
+
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC
+2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+### ASA Parameters Conventions
+
+The ASA parameters of Soul Bound NFTs should follow the conventions for NFT tokens defined in [ARC-0003](https://arc.algorand.foundation/ARCs/arc-0003)
+except for the following parameters:
+
+* *Manager Address* (`m`): **MUST** be set to issuing address to establish provenance.
+* *Clawback Address* (`c`): **MUST** be set empty, to indicate that clawback is not permitted.
+* *Default Frozen* (`df`): **MUST** be _True_ to freeze holdings for the asset by default.
+* *Freeze Address* (`f`): **MUST** be set to `""` or empty, to indicate that unfreezing is not permitted.
+
+### Transaction Validation
+
+### Inputs that Must Be Systematically Rejected
+
+The ASA transaction validation of Soul Bound NFTs should follow the validation for Algorand Wallet Transaction Signing API defined in [ARC-0001](https://arc.algorand.foundation/ARCs/arc-0001)
+except for the following parameters:
+* Transaction Object Type AssetTransferTx with AssetCloseTo `AssetTransferTx.AssetCloseTo` with not empty value **MUST** be rejected
+* Transaction Object Type PaymentTx with CloseRemainderTo `PaymentTx.CloseRemainderTo` with not empty value **MUST** be rejected
+
+## Rationale
+
+For a NFT token to be described as Soul Bound, it must be meet the following criteria:
+1. Publicly verifiable
+2. Non-fungible
+3. Non-transferable
+
+The Algorand blockchain provides the instruments for publicly verifiable transactions. The [ARC-0003](https://arc.algorand.foundation/ARCs/arc-0003)
+sets the conventions for creating non-fungible tokens.
+To make NFTs non-transferable, thereby becoming Soul Bound, the asset _Manager Address_, _Default Frozen_, _Clawback Address_, and _Freeze Address_
+parameters must be modified as specified above.
+
+## References
+
+**Standards**
+- [ARC-0001 Algorand Wallet Transaction Signing API](https://arc.algorand.foundation/ARCs/arc-0001)
+- [ARC-0003 Algorand Standard Asset Parameters Conventions for Fungible and Non-Fungible Tokens](https://arc.algorand.foundation/ARCs/arc-0003)
+- [RFC 2119 Key words for use in RFCs to Indicate Requirement Levels](https://www.ietf.org/rfc/rfc2119.txt)
+
+**Articles & Discussions**
+- [Decentralized Society: Finding Web3's Soul](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4105763)
+- [Soulbound](https://vitalik.eth.limo/general/2022/01/26/soulbound.html)
+- [What are Soulbound Tokens](https://dev.to/envoy_/what-are-soulbound-tokens-14lj)
+
+## Copyright
+
+Copyright and related rights waived via
+[CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Adding a line of the ARC to provide context

> A "Soul Bound NFT" is an Algorand Standard Asset (ASA) controlled by a Smart Contract
> that exposes methods to create, configure and destroy the
> asset.

This PR is issued in the context of the [Hackathon: Algorand GreenHouse Hack#1 Soul Bound NFTs ARC](https://gitcoin.co/issue/29133)