### PR TITLE
ARC4 - adding boxes

### DIFF
--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -522,7 +522,7 @@ any leading zeros, _unless_ `N` is zero, in which case only a single 0 character
 * `<type>[]`: A variable-length array. `type` can be any other type.
 * `string`: A variable-length byte array (`byte[]`) assumed to contain UTF-8 encoded content.
 * `(T1,T2,…,TN)`: A tuple of the types `T1`, `T2`, …, `TN`, `N >= 1`.
-* reference types `account`, `asset`, `application`: **MUST NOT** be used as the return type.
+* reference types `account`, `asset`, `application`, `box`: **MUST NOT** be used as the return type.
 For encoding purposes they are an alias for `uint8`. See section "Reference Types" below.
 
 Additional special use types are defined in [Reference Types](#reference-types)
@@ -596,15 +596,16 @@ They _can_ be embedded in arrays and tuples.
 * `account` represents an Algorand account, stored in the Accounts (`apat`) array
 * `asset` represents an Algorand Standard Asset (ASA), stored in the Foreign Assets (`apas`) array
 * `application` represents an Algorand Application, stored in the Foreign Apps (`apfa`) array
+* `box` represents a Box owned by an Algorand Application, stored in the Boxes (`apbx`) array
 
 Some AVM opcodes require specific values to be placed in the "foreign
-arrays" of the Application call transaction. These three types allow
+arrays" of the Application call transaction. These four types allow
 methods to describe these requirements. To encode method calls that
 have these types as arguments, the value in question is placed in the
-Accounts (`apat`), Foreign Assets (`apas`), or Foreign Apps (`apfa`)
-arrays, respectively, and a `uint8` containing the index of the value
-in the appropriate array is encoded in the normal location for this
-argument.
+Accounts (`apat`), Foreign Assets (`apas`), Foreign Apps (`apfa`) 
+or Boxes (`apbx`) arrays, respectively, and a `uint8` containing the 
+index of the value in the appropriate array is encoded in the normal 
+location for this argument.
 
 Note that the Accounts and Foreign Apps arrays have an implicit value
 at index 0, the Sender of the transaction or the called Application,


### PR DESCRIPTION
An upcoming release of Algorand allows Applications to create and manage `Boxes`, a named set of bytes owned by the Application that created it.

In order to read or write to a box, it _MUST_ be specified in the ApplicationCallTransaction much like the current requirement for Assets/Apps/Accounts.

This PR introduces boxes as a reference type to be encoded in the same way as other reference types.