### PR TITLE
ARC-28 Events

### DIFF
--- a/ARCs/arc-0028.md
+++ b/ARCs/arc-0028.md
@@ -37,6 +37,8 @@ This is the same process that is used by the [ABI Method Selector ](./arc-0004.m
 
 #### Event
 
+An event is represented as follow:
+
 ```typescript
 interface Event {
   /** The name of the event */
@@ -56,6 +58,8 @@ interface Event {
 ```
 
 #### Method
+
+This ARC extends ARC-4 by adding an array events of type Event[] to the Method interface. Concretely, this give the following extended Method interface:
 
 ```typescript
 interface Method {
@@ -84,22 +88,8 @@ interface Method {
 }
 ```
 
-#### Interface
-> Same as ARC-4, events are already inside `Method`
-
-```typescript
-interface Interface {
-  /** A user-friendly name for the interface */
-  name: string;
-  /** Optional, user-friendly description for the interface */
-  desc?: string;
-  /** All of the methods that the interface contains */
-  methods: Method[];
-}
-```
-
 #### Contract
-> Even if events are already inside `Method`, might be better for readability to have and array of `Events`
+> Even if events are already inside `Method`, the contract **MUST** provide an array of `Events` to improve readability.
 
 ```typescript
 interface Contract {

--- a/ARCs/arc-0028.md
+++ b/ARCs/arc-0028.md
@@ -59,7 +59,7 @@ interface Event {
 
 #### Method
 
-This ARC extends ARC-4 by adding an array events of type Event[] to the Method interface. Concretely, this give the following extended Method interface:
+This ARC extends ARC-4 by adding an array events of type `Event[]` to the `Method` interface. Concretely, this give the following extended Method interface:
 
 ```typescript
 interface Method {

--- a/ARCs/arc-0028.md
+++ b/ARCs/arc-0028.md
@@ -4,7 +4,7 @@ title: Algorand Event Log Spec
 description: A methodology for structured logging by Algorand dapps.
 author: Dan Burton (@DanBurton)
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/144
-status: Draft
+status: Last Call
 type: Standards Track
 category: ARC
 created: 2022-07-18


### PR DESCRIPTION
To improve readability:
ARC-4 Interface inside the extension has been removed and replaced by a sentence explaining what we are adding.