### PR TITLE
ARC-72. Application Non-Fungible Token

### DIFF
--- a/ARCs/arc-0072.md
+++ b/ARCs/arc-0072.md
@@ -1,0 +1,208 @@
+---
+arc: 72
+title: Application Non-Fungible Token
+description: An application's interface for non-fungible tokens, also known as deeds.
+author: Stéphane BARROSO (@sudoweezy)
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/
+status: Draft
+type: Standards Track
+category: Interface
+created: 2022-11-14
+requires: 4, 16, 28
+---
+
+
+## Abstract
+
+The following standard allows for the implementation of an Interface for NFTs within Application. 
+This interface allows dApps to work with [ARC-72](./arc-0072.md) NFTs on Algorand. It provides basic functionality to track and transfer NFTs.
+This standard is inspired by the <a href="https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md ">EIP-721 Ethereum Standards token standard </a>  
+
+## Specification
+
+
+The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC-2119</a>.
+
+> Comments like this are non-normative.
+
+**Every ARC-72 compliant application must implement the following interfaces**:
+
+> Events are emitted based on [ARC-28](./arc-0028.md)
+
+```json
+interface ARC72 /* is ARC72 */ {
+    /// @dev This emits when ownership of any NFT changes by any mechanism.
+    ///  This event emits when NFTs are created (`from` == 0) and destroyed
+    ///  (`to` == 0). Exception: during application creation, any number of NFTs
+    ///  may be created and assigned without emitting Transfer. At the time of
+    ///  any transfer, the approved address for that NFT (if any) is reset to none.
+    event Transfer(address indexed _from, address indexed _to, uint256 indexed _tokenId);
+
+    /// @dev This emits when the approved address for an NFT is changed or
+    ///  reaffirmed. The zero address indicates there is no approved address.
+    ///  When a Transfer event emits, this also indicates that the approved
+    ///  address for that NFT (if any) is reset to none.
+    event Approval(address indexed _owner, address indexed _approved, uint256 indexed _tokenId);
+
+    /// @dev This emits when an operator is enabled or disabled for an owner.
+    ///  The operator can manage all NFTs of the owner.
+    event ApprovalForAll(address indexed _owner, address indexed _operator, bool _approved);
+
+    /// @notice Count all NFTs assigned to an owner
+    /// @dev NFTs assigned to the zero address are considered invalid, and this
+    ///  function throws for queries about the zero address.
+    /// @param _owner An address for whom to query the balance
+    /// @return The number of NFTs owned by `_owner`, possibly zero
+    function balanceOf(address _owner) external view returns (uint256);
+
+    /// @notice Find the owner of an NFT
+    /// @dev NFTs assigned to zero address are considered invalid, and queries
+    ///  about them do throw.
+    /// @param _tokenId The identifier for an NFT
+    /// @return The address of the owner of the NFT
+    function ownerOf(uint256 _tokenId) external view returns (address);
+
+    /// @notice Transfers the ownership of an NFT from one address to another address
+    /// @dev Throws unless `msg.sender` is the current owner, an authorized
+    ///  operator, or the approved address for this NFT. Throws if `_from` is
+    ///  not the current owner. Throws if `_to` is the zero address. Throws if
+    ///  `_tokenId` is not a valid NFT. When transfer is complete, this function
+    ///  checks if `_to` is a application (code size > 0). If so, it calls
+    ///  `onARC72Received` on `_to` and throws if the return value is not
+    ///  `bytes4(keccak256("onARC72Received(address,address,uint256,bytes)"))`.
+    /// @param _from The current owner of the NFT
+    /// @param _to The new owner
+    /// @param _tokenId The NFT to transfer
+    /// @param data Additional data with no specified format, sent in call to `_to`
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes data) external payable;
+
+    /// @notice Transfers the ownership of an NFT from one address to another address
+    /// @dev This works identically to the other function with an extra data parameter,
+    ///  except this function just sets data to "".
+    /// @param _from The current owner of the NFT
+    /// @param _to The new owner
+    /// @param _tokenId The NFT to transfer
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId) external payable;
+
+    /// @notice Transfer ownership of an NFT -- THE CALLER IS RESPONSIBLE
+    ///  TO CONFIRM THAT `_to` IS CAPABLE OF RECEIVING NFTS OR ELSE
+    ///  THEY MAY BE PERMANENTLY LOST
+    /// @dev Throws unless `msg.sender` is the current owner, an authorized
+    ///  operator, or the approved address for this NFT. Throws if `_from` is
+    ///  not the current owner. Throws if `_to` is the zero address. Throws if
+    ///  `_tokenId` is not a valid NFT.
+    /// @param _from The current owner of the NFT
+    /// @param _to The new owner
+    /// @param _tokenId The NFT to transfer
+    function transferFrom(address _from, address _to, uint256 _tokenId) external payable;
+
+    /// @notice Change or reaffirm the approved address for an NFT
+    /// @dev The zero address indicates there is no approved address.
+    ///  Throws unless `msg.sender` is the current NFT owner, or an authorized
+    ///  operator of the current owner.
+    /// @param _approved The new approved NFT controller
+    /// @param _tokenId The NFT to approve
+    function approve(address _approved, uint256 _tokenId) external payable;
+
+    /// @notice Enable or disable approval for a third party ("operator") to manage
+    ///  all of `msg.sender`'s assets
+    /// @dev Emits the ApprovalForAll event. The application MUST allow
+    ///  multiple operators per owner.
+    /// @param _operator Address to add to the set of authorized operators
+    /// @param _approved True if the operator is approved, false to revoke approval
+    function setApprovalForAll(address _operator, bool _approved) external;
+
+    /// @notice Get the approved address for a single NFT
+    /// @dev Throws if `_tokenId` is not a valid NFT.
+    /// @param _tokenId The NFT to find the approved address for
+    /// @return The approved address for this NFT, or the zero address if there is none
+    function getApproved(uint256 _tokenId) external view returns (address);
+
+    /// @notice Query if an address is an authorized operator for another address
+    /// @param _owner The address that owns the NFTs
+    /// @param _operator The address that acts on behalf of the owner
+    /// @return True if `_operator` is an approved operator for `_owner`, false otherwise
+    function isApprovedForAll(address _owner, address _operator) external view returns (bool);
+}
+```
+
+The **metadata extension** is OPTIONAL for ARC-72 applications (see "caveats", below). This allows your application to be interrogated for its name and for details about the assets which your NFTs represent.
+
+```json
+interface ARC72Metadata /* is ARC72 */ {
+    /// @notice A descriptive name for a collection of NFTs in this application
+    function name() external view returns (string _name);
+
+    /// @notice An abbreviated name for NFTs in this application
+    function symbol() external view returns (string _symbol);
+
+    /// @notice A distinct Uniform Resource Identifier (URI) for a given asset.
+    /// @dev Throws if `_tokenId` is not a valid NFT. URIs are defined in RFC
+    ///  3986. The URI may point to a JSON file that conforms to the "ARC72
+    ///  Metadata JSON Schema".
+    function tokenURI(uint256 _tokenId) external view returns (string);
+}
+```
+
+This is the "ARC-72 Metadata JSON Schema" referenced above **SHOULD** follow the [ARC-16](./arc-0016.md)
+
+
+The **enumeration extension** is OPTIONAL for ARC-72 applications. This allows your application to publish its full list of NFTs and make them discoverable.
+
+```json
+interface ARC72Enumerable /* is ARC72 */ {
+    /// @notice Count NFTs tracked by this application
+    /// @return A count of valid NFTs tracked by this application, where each one of
+    ///  them has an assigned and queryable owner not equal to the zero address
+    function totalSupply() external view returns (uint256);
+
+    /// @notice Enumerate valid NFTs
+    /// @dev Throws if `_index` >= `totalSupply()`.
+    /// @param _index A counter less than `totalSupply()`
+    /// @return The token identifier for the `_index`th NFT,
+    ///  (sort order not specified)
+    function tokenByIndex(uint256 _index) external view returns (uint256);
+
+    /// @notice Enumerate NFTs assigned to an owner
+    /// @dev Throws if `_index` >= `balanceOf(_owner)` or if
+    ///  `_owner` is the zero address, representing invalid NFTs.
+    /// @param _owner An address where we are interested in NFTs owned by them
+    /// @param _index A counter less than `balanceOf(_owner)`
+    /// @return The token identifier for the `_index`th NFT assigned to `_owner`,
+    ///   (sort order not specified)
+    function tokenOfOwnerByIndex(address _owner, uint256 _index) external view returns (uint256);
+
+}
+```
+
+## Rationale
+
+Algorand Standard Asset can be used for creating NFTs, however, with the release of Box Storage, in **MIGHT** be more efficient to use one application who handle multiple NFTs.
+
+**NFT Identifiers**
+
+Every NFT is identified by a unique `uint256` ID inside the ARC-72 application. This identifying number SHALL NOT change for the life of the application. The pair `(application address, uint256 tokenId)` will then be a globally unique and fully-qualified identifier for a specific asset on an Ethereum chain. While some ARC-72 applications may find it convenient to start with ID 0 and simply increment by one for each new NFT, callers SHALL NOT assume that ID numbers have any specific pattern to them, and MUST treat the ID as a "black box". Also note that NFTs MAY become invalid (be destroyed). Please see the enumeration functions for a supported enumeration interface.
+
+The choice of `uint256` allows a wide variety of applications because UUIDs and sha3 hashes are directly convertible to `uint256`.
+
+**Transfer Mechanism**
+
+ARC-72 standardizes a safe transfer function `safeTransferFrom` (overloaded with and without a `bytes` parameter) and an unsafe function `transferFrom`. Transfers may be initiated by:
+
+- The owner of an NFT
+- The approved address of an NFT
+- An authorized operator of the current owner of an NFT
+
+Additionally, an authorized operator may set the approved address for an NFT. This provides a powerful set of tools for dApps to quickly use a *large* number of NFTs.
+
+Creation of NFTs ("minting") and destruction of NFTs ("burning") is not included in the specification. Your application may implement these by other means.
+
+## Backwards Compatibility
+
+dApps will need to have a new implementation to handle ARC-72 NFTs.
+
+## Security Considerations
+
+## Copyright
+
+Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.


### PR DESCRIPTION
It is a first draft inspired by ERC-721 for NFT inside an Application using box storage.

It is needed for:
Creator, to create NFT without using ASA
Wallets, when you Buy/Trade, NFTs need to be displayed properly inside the transaction window
dApps, to display and use NFTs

