### PR TITLE
Arc-0008 Update of security consideration for dApps (Waiting Screen)

### DIFF
--- a/ARCs/arc-0008.md
+++ b/ARCs/arc-0008.md
@@ -46,7 +46,7 @@ In case the wallet uses an API service that is secret or provided by the user, t
 
 > Leakage may happen by accidentally including too much information in responses or errors returned by the various methods. For example, if the nodeJS superagent library is used without filtering errors and responses, errors and responses may include the request object, which includes the potentially secret API service URL / secret token headers.
 
-For dApps using the `signAndPostTxns` function, it is **RECOMMENDED** to display a Waiting Screen until the transaction is confirmed to prevent potential issues.
+For dApps using the `signAndPostTxns` function, it is **RECOMMENDED** to display a Waiting/Loading Screen to wait until the transaction is confirmed to prevent potential issues.
 
 ## Copyright
 

--- a/ARCs/arc-0008.md
+++ b/ARCs/arc-0008.md
@@ -34,12 +34,6 @@ export type SignAndPostTxnsFunction = (
 
 Errors are handled exactly as specified by [ARC-0001](./arc-0001.md#error-standards) and [ARC-0007](./arc-0007.md#error-standard)
 
-### Security considerations
-
-In case the wallet uses an API service that is secret or provided by the user, the wallet **MUST** ensure that the URL of the service and the potential tokens/headers are not leaked to the dApp.
-
-> Leakage may happen by accidentally including too much information in responses or errors returned by the various methods. For example, if the nodeJS superagent library is used without filtering errors and responses, errors and responses may include the request object, which includes the potentially secret API service URL / secret token headers.
-
 ## Rationale
 
 Allows the user to be sure that what they are signing is in fact all that is being sent. Doesn't necessarily grant the DApp direct access to the signed txns, though they are posted to the network, so they should not be considered private.
@@ -48,7 +42,11 @@ Exposing only this API instead of exposing `postTxns` directly is potentially sa
 
 ## Security Considerations
 
-None.
+In case the wallet uses an API service that is secret or provided by the user, the wallet **MUST** ensure that the URL of the service and the potential tokens/headers are not leaked to the dApp.
+
+> Leakage may happen by accidentally including too much information in responses or errors returned by the various methods. For example, if the nodeJS superagent library is used without filtering errors and responses, errors and responses may include the request object, which includes the potentially secret API service URL / secret token headers.
+
+For dApps using the `signAndPostTxns` function, it is **RECOMMENDED** to display a Waiting Screen until the transaction is confirmed to prevent potential issues.
 
 ## Copyright
 

--- a/ARCs/arc-0008.md
+++ b/ARCs/arc-0008.md
@@ -48,6 +48,8 @@ In case the wallet uses an API service that is secret or provided by the user, t
 
 For dApps using the `signAndPostTxns` function, it is **RECOMMENDED** to display a Waiting/Loading Screen to wait until the transaction is confirmed to prevent potential issues.
 
+> The reasoning is the following: the pop-up/window in which the wallet is showing the waiting/loading screen may disappear in some cases (e.g., if the user clicks away from it). If it disappears, the user may be tempted to perform again the action, causing significant damages.
+
 ## Copyright
 
 Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.


### PR DESCRIPTION
I propose to add a recommendation inside the security consideration for dApps using the `signAndPostTxns` function to avoid potential issues (eg: Multiple submissions of transactions).
