### PR TITLE
An alternative xGovernance community proposal

### DIFF
--- a/ARCs/arc-0033.md
+++ b/ARCs/arc-0033.md
@@ -1,0 +1,120 @@
+---
+arc: 33
+title: xGovernance
+description: Explanation of the xGovernance system.
+author: Miklos Bertalan (@solkimicreb)
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/
+status: Draft
+type: Meta
+created: 2022-12-19
+---
+
+# The xGovernance System
+
+This document describes an extension to the current governance system to a total of three governance roles: Governor, xGovernor, and the Foundation.
+
+- Governors elect xGovernors and vote about topics proposed by xGovernors.
+- xGovernors propose new votes and filter them to be propagated for governance votes.
+- The Foundation acts as an xGovernor and as a moderator with veto power. It is responsible for implementing the result of governance votes.
+
+## Motivation
+
+The [current xGovernor proposal](https://github.com/algorandfoundation/ARCs/pull/152/files) ties the xGovernor role to participating in certain reward-bearing projects. These projects would be picked by the Foundation, which goes against democratization. Moreover involving any token or project other than Algo itself in the governance of the ecosystem makes us vulnerable to single-project failures.
+
+## Registration, Participation, Eligibility, and Rewards
+
+### Governors
+
+Governors **MUST** commit an arbitrary Algo balance at the start of the governance period and they **MUST NOT** fall below this balance until the end of the period. Falling below the committed balance at any point or not participating in at least 2/3 of the votes disqualifies the Governor from the current governance period.
+
+Governors who are not disqualified at the end of the governance period receive a part of a shared reward pool proportional to their committed Algos.
+
+### xGovernor Application and Eligibility
+
+xGovernors applicants **MUST** have a linked NFD with at least one verified contact method (twitter, email, etc) and they **SHOULD** answer community concerns and questions through verified contacts.
+
+xGovernor applicants **MUST** commit at least 100,000 Algo at the start of the governance period and they **MUST NOT** fall below their committed balance until the end of the period. Falling below the committed balance at any point disqualifies the xGovernor from the current governance period. xGovernors can not be disqualified by not participating in enough xGovernor votes.
+
+A single address **MAY** commit Algos as both governor and xGovernor but the same Algo can not be committed for both xGovernance and governance.
+
+### xGovernor Election and Rewards
+
+Every community governance period **MUST** start with a 7-day xGovernor election for the  **current** period. The election **MUST** include all xGovernor applicants who successfully applied until the start of the election and did not drop below their committed xGovernor balance. The applicant list **MUST** clearly display the applicants' verified NFD and communication channels to let voters identify them.
+
+Governors **MAY** support multiple xGovernors with the weight of their committed Algos. The top 100 most supported xGovernor applicants are elected as xGovernors for the **current** governance period. xGovernors are elected for a single period but they **MAY** be reelected without limits.
+
+xGovernor applicants who are not elected for the given period **MAY** recommit their xGovernor Algo commitment as normal governance commitment for a 3-day period after the xGovernor election.
+
+xGovernors do not receive rewards for their participation in this phase. Rewards should be decided via a governance vote once the system is online.
+
+### The Algorand Foundation
+
+The Foundation **MUST** participate as an xGovernor and **MUST NOT** participate as a normal governor in the system. The Foundation is naturally an xGovernor, it does not need to be elected.
+
+## Lifecycle of a Vote
+
+### Proposal Creation
+
+> A **vote** is a description of an issue and an attached selection of voting options about the issue.
+
+xGovernors **MAY** create `committed_algos / minimum_required_committed_algos` (rounded down) vote proposals at any time during the governance period. A vote proposal **MUST** contain a short description of the issue and at least 2 voting options, and it MAY contain links to more detailed documents about the topic.
+
+A proposal is only visible to the creator address before it is submitted to review or voting.
+
+### Proposal Review
+
+xGovernors **SHOULD** submit their vote proposals to an initial review period at any time during the governance period. Proposals and linked documents **MAY** be edited during this period and they are completely public once they are submitted to review or vote. 
+
+xGovernors **MAY** add comments with objective data or personal opinions to votes in the review period, and later during the xGovernance and community vote periods. Comments **MUST** remain visible forever and **MUST NOT** be edited or deleted. Comments **MAY** be corrected by subsequent response comments.
+
+None xGovernor users **MUST NOT** comment on proposals but they **SHOULD** contact xGovernors to express their opinion and potentially get it represented through them.
+
+### Proposal Submission
+
+xGovernors **MAY** submit their proposals with or without a previous review period but proposals and linked documents **MUST NOT** be modified after the submission.
+
+Submitted proposals are completely public and the commenting rules from [Proposal Review](#proposal-review) apply to them. Unsubmitted and non-winning proposals **MAY** be resubmitted during the next governance period by any xGovernor. The resubmitting xGovernor **SHOULD** be the original one. In case a new xGovernor resubmits a proposal they **MUST** consult and credit the original proposer.
+
+### xGovernance
+
+xGovernors **MAY** support any number of submitted proposals with the weight of their committed Algos but they **MUST NOT** support their own proposals. Submitted proposals are all open until the end of the governance period. While a proposal is open xGovernors **MAY** submit, cancel or edit their support towards the proposal, only their final support counts.
+
+The top 8 most supported proposals at the end of the governance period are selected as community votes in the **next** governance period with the following exceptions:
+
+- Selected votes must be supported by at least 2/3 of all committed xGovernor Algos. In case this is not satisfied at least the top 4 votes are selected regardless if they have a minimum of 2/3 support.
+
+### Community Governance
+
+The most supported proposals from the **previous** xGovernance period form the community governance votes for the **current** period. All of the community votes are publicly displayed from the start of the period and xGovernors **MAY** publicly comment on them at any time.
+
+The votes are ordered from most supported to least supported (by xGovernor preselection) and equally distributed in time during the governance period, after the [xGovernor election](#xgovernor-election-and-rewards). Each vote **MUST** clearly display the proposer xGovernor with their NFD and contact information, the vote description with potentially linked documents, the voting options, and all attached comments by xGovernors. Each vote **MUST** stay open for 7 days for the community to vote on.
+
+The community **MUST** have veto power for all votes. Once a vote propagates to community governance it **MUST** be extended with an extra voting option to completely disregard the vote and any of its described effects.
+
+### Foundation Veto
+
+The Foundation **MAY** veto any community vote result between the end of the specific vote and the end of the governance period with the following notes:
+
+- The Foundation **MUST NOT** veto a vote before the end of the democratic process. A vote must be selected by the xGovernors and voted by the community with a clear democratic result before a veto can occur.
+- The veto **MUST** be clearly indicated next to the original vote result with reasoning.
+- Veto is a stopping power, not a choosing one. The Foundation **MUST** completely disregard the vote result, it **MUST NOT** pick a non-winning option to implement as the result of the vote.
+
+### Implementation of the Result
+
+The Foundation **MUST** implement the result of non-vetoed community votes after the governance period. The Foundation **MUST** follow the directions specified by the vote description and winning option but **MAY** freely interpret any part of the vote which is not strictly specified. The Foundation **SHOULD** be inspired by xGovernor comments where the vote specification is lacking.
+
+The Foundation can outsource the implementation and fund it with community funds with the following notes:
+
+- The financing of the implementation **MUST** be publicly and transparently documented.
+- In case of outsourcing the implementor **MUST** be publicly announced with an attached contact method.
+
+The Foundation **MAY** implement changes on its own without a prior proposal and vote with the following notes:
+
+- These implementations **MUST** be clearly indicated to be non-vote results in all references and documents.
+- The financing of these implementations **MUST** be publicly and transparently documented.
+
+## Notes
+
+- Thanks, [Agash](https://twitter.com/agashnava) for the NFD verification idea.
+- This proposal is more detailed and specific on purpose. I find it easier and more convenient to argue about the big picture and the details at the same time. I am happy to adapt any part of it, be it a major change or just some number tweaks.
+- Thanks for reading. I am sure you have ideas, please comment!


### PR DESCRIPTION
The [current xGovernor proposal](https://github.com/algorandfoundation/ARCs/pull/152/files) ties the xGovernor role to participating in certain reward-bearing projects. These projects would be picked by the Foundation, which goes against democratization. Moreover involving any token or project other than Algo itself in the governance of the ecosystem makes us vulnerable to single-project failures.

The goal of this proposal is to rethink these issues and spark a different and parallel discussion to eventually reach a common conclusion.