### PR TITLE
ARC-29: Extension of Arc-23 to identify interfaces of an application

### DIFF
--- a/ARCs/arc-0029.md
+++ b/ARCs/arc-0029.md
@@ -1,0 +1,114 @@
+---
+arc: 29
+title: Interface detection
+description: Specification to identify interfaces of applications
+author: Stéphane Barroso (@sudoweezy)
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/166
+status: Draft
+type: Standards Track
+category: Interface
+created: 2023-01-30
+require: 23
+---
+
+## Abstract
+
+The following document introduces an extension of [ARC-23](arc-0023.md).
+
+The goal of this convention is to standardize the process to identify interfaces of applications, by appending interface's ARC to the compiled application's bytes. 
+
+## Specification
+
+The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC-2119</a>.
+
+> Comments like this are non-normative.
+
+### String containing Application's Interfaces
+An application's interface is represented by an ARC number.
+
+The string represents and array of Application's Interfaces that:
+
+* **MUST** starts with a string  `arc29` 
+
+* **MUST** contains ARC's number separated 
+
+
+> eg: if an application follow interfaces from ARCs XX & YY & ZZ, the corresponding string will be `arc29 XX YY ZZ `
+
+### Associated Encoded Information Byte String
+
+The (encoded) information byte string is the array of the previous section.
+
+The information byte string always starts, in hexadecimal with `0x6172633239` (corresponding to `arcs29`).
+
+> Example: for the following `arcs29 1 20 300`, the list of interfaces to the following hexadecimal value: 
+>
+> ```
+> 0x6172633239 0x01 0x14 0x012c
+> ```
+
+### Inclusion of the Encoded Information Byte String in Programs
+
+The encoded information byte string is included in the *approval program* of the application via a <a href="https://developer.algorand.org/docs/get-details/dapps/avm/teal/opcodes/#bytecblock-bytes">`bytecblock`</a> with a unique byte string equal to the encoding information byte string.
+
+> For the example above, the `bytecblock` is:
+>
+> ```
+> bytecblock 0x6172633239 0x01 0x14 0x012c
+> ```
+>
+The size of the compiled application plus the bytecblock **MUST** be, at most, the maximum size of a compiled application according to the latest consensus parameters supported by the compiler.
+
+> At least with TEAL v8 and before, appending the previous `bytecblock` to the end of the program should add exactly 17 bytes:
+>   1 byte for 0x26 opcode `bytecblock`
+>   1 byte for 0x04 -the number of byte strings-
+>   1 byte for 0x05 the length of the encoded information 1st byte string
+>   5 byte for 0x6172633239 the `arc29`
+>   1 byte for 0x01 the length of the encoded information 2nd byte string
+>   1 byte for 0x01 the `1`
+>   1 byte for 0x02 the length of the encoded information 3rd byte string
+>   2 byte for 0x14 the `20`
+>   1 byte for 0x03 the length of the encoded information 4th byte string
+>   3 byte for 0x012c the `300`
+
+The `bytecblock` **MAY** be placed anywhere in the TEAL source code as long as it does not modify the semantic of the TEAL source code.
+The `bytecblock` **SHOULD** be the last opcode of the deployed TEAL program.
+
+Developers **MUST** check that, when adding the `bytecblock` to their program, semantic is not changed.
+
+### Retrieval the Encoded Information Byte String and CID from Compiled TEAL Programs
+
+For programs until TEAL v8, a way to find the encoded information byte string is to search for the prefix:
+
+```
+6172633239
+```
+Indeed, this prefix is composed of:
+* 0x6172633239, the hexadecimal of `arc29`
+
+Software retrieving the encoded information byte string **SHOULD** check the TEAL version and only perform retrieval for supported TEAL version.
+They also **SHOULD** gracefully handle false positives, that is when the above prefix is found multiple times.
+
+
+Note that opcode encoding may change with the TEAL version (though this did not happen up to TEAL v8 at least).
+If the `bytecblock` opcode encoding changes, software that extract the encoded information byte string from compiled TEAL programs **MUST** be updated.
+
+## Rationale
+
+By appending the interfaces standards of an Application, any user with access to the blockchain could interact with an application without having to check the ABI.
+
+## Reference Implementation
+
+The following codes are not audited and are only here for information purposes.
+
+Here is an example of a python script that can generate the hash and append it to the compiled application, according this ARC:
+[main.py](../assets/arc-0029/main.py).
+
+## Security Considerations
+An `arc-29 added at the end of an application is here to share information, not proof of anything.
+Interfaces are only here to help users to interact with the application. 
+It is the users reponsability to ensure that the application conforms. 
+
+## Copyright
+
+Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.

--- a/assets/arc-0029/application_information/application.py
+++ b/assets/arc-0029/application_information/application.py
@@ -1,0 +1,45 @@
+from pyteal import * #pyteal==0.20.1
+
+def calc():
+    return Cond(
+        [
+            Txn.application_args.length() == Int(0),
+            Cond(
+                [Txn.application_id() == Int(0), Approve()],
+                [Txn.on_completion() == OnComplete.OptIn, Approve()],
+                [Txn.on_completion() == OnComplete.CloseOut, Approve()],
+                [Txn.on_completion() == OnComplete.DeleteApplication, Reject()],
+                [Txn.on_completion() == OnComplete.UpdateApplication, Reject()],
+            )
+        ],
+        [
+            Txn.on_completion() == OnComplete.NoOp,
+            Cond(
+                [
+                    Txn.application_args[0] == Bytes('base16', 'fe6bdf69'),  # add(uint64,uint64)uint64
+                    Seq([
+                        Log(
+                            Concat(
+                                Bytes('base16', '151f7c75'),
+                                Itob(Add(Btoi(Txn.application_args[1]), Btoi(Txn.application_args[2])))
+                            )
+                        ),
+                        Approve()
+                    ])
+                ],
+                [
+                    Txn.application_args[0] == Bytes('base16', '766083a7'),  # multiply(uint64,uint64)uint64
+                    Seq([
+                        Log(
+                            Concat(
+                                Bytes('base16', '151f7c75'),
+                                Itob(Mul(Btoi(Txn.application_args[1]), Btoi(Txn.application_args[2])))
+                            )
+                        ),
+                        Approve()
+                    ])
+                ],
+
+            )
+        ]
+    )

--- a/assets/arc-0029/main.py
+++ b/assets/arc-0029/main.py
@@ -1,0 +1,121 @@
+import base64
+import binascii
+from algosdk.v2client import algod
+from pyteal import compileTeal, Mode
+
+from application_information.application import calc
+
+# This programs assumes Kubo IPFS version 0.17.0
+# is installed, in the PATH, and initialized (ipfs init)
+
+# General parameters (assumes sandbox)
+
+algod_token = "a" * 64
+algod_address = "http://localhost:4001"
+
+verbose = False
+
+def compile_program(client: algod.AlgodClient, teal_script: str) -> bytes:
+    compile_response = client.compile(teal_script)
+    return base64.b64decode(compile_response["result"])
+
+def get_interface_from_compiled_program(compiled_program: bytes) -> bytes:
+    """
+    Retrieve the interfaces from a compiled program.
+    Return None if not found
+    """
+
+    # Production code SHOULD check the TEAL version of the compiled_program first
+    # and be updated to support different encoding for bytecblock for potential future TEAL versions
+
+    prefix = bytes.fromhex("2604056172633239")
+
+    # 0x26 is the bytecblock opcode, 0x04 is the number of []byte strings,
+    # 0x05 is the length = 5 bytes, 0x6172633239 is hexadecimal of `arc29`
+
+    count_query = compiled_program.count(prefix)
+    if count_query > 1:
+        # The program contains several potential arc29 pattern
+        # A production code would actually try each of them
+        # but this code is more basic and will just fail
+        return None
+
+    if count_query == 0:
+        # arc29 pattern not present
+        return None
+
+    idx = compiled_program.index(prefix) + len(prefix)
+    if len(compiled_program) < idx + 7:
+        # This was a false positive: there are not enough bytes after the prefix
+        return None
+
+    binary_interfaces = compiled_program[idx:idx + 7]
+    hex_binary = binary_interfaces.hex()
+
+    i = 0
+    list_interfaces = []
+    while i < len(hex_binary):
+        # We get the length of the encoded decimal integer
+        idx = int(hex_binary[i:i+2], 16)*2
+        # We get each encoded decimal integer
+        value = hex_binary[i+2: i+2+idx]
+        list_interfaces.append(int(value, 16))
+        i = i + idx + 2 
+    return list_interfaces
+
+
+def int_to_bytes(x: int) -> bytes:
+    return x.to_bytes((x.bit_length() + 7) // 8, 'big')
+
+def int_to_hex(x: int) -> bytes:
+    return int_to_bytes(x).hex()
+
+
+def main():
+    # Connect to an algod client
+    algod_client = algod.AlgodClient(algod_token=algod_token, algod_address=algod_address)
+
+    # Convert the PyTEAL approval program into a TEAL script
+    teal_script = compileTeal(calc(), mode=Mode.Application, version=5)
+
+    # Compile the program without information
+    compiled_program_wo_information = compile_program(algod_client, teal_script)
+
+    # Compute the information bytes
+    information_bytes = [b"arc29".hex(), int_to_hex(1) ,int_to_hex(20) ,int_to_hex(300)]
+    # We need to have ['6172633239', '01', '14', '012c'] 
+    # We take for the example ARC1 ARC20 & ARC300
+
+    # Append it to the contract
+    bytecblock = f'bytecblock {" ".join("0x" + b for b in information_bytes)}'
+    assert bytecblock == "bytecblock 0x6172633239 0x01 0x14 0x012c"
+    # For number > 256, be sure to have them on 4 digit (eg 300 -> 012c)
+    # Append a bytecblock containing the byte string `information_bytes`
+    # at the end of provided teal_script
+    teal_script_with_information = f'{teal_script}\n{bytecblock}\n'
+    if verbose:
+        print("New TEAL script:")
+        print(teal_script_with_information)
+        print("----------------")
+
+    # Compile the program
+    compiled_program = compile_program(algod_client, teal_script_with_information)
+
+    # Check that the new program is the old program concatenated with
+    # 0x26040561726332390101011402012c
+    # where 2604056172633239 is the prefix described above in `get_interface_from_compiled_program`
+    # where 0101 is "1" and 01 is the number of bytes
+    # where 0114 is "20" and 01 is the number of bytes
+    # where 02012c is "300" and 02 is the number of bytes
+    assert compiled_program == \
+           compiled_program_wo_information +\
+           bytes.fromhex("26040561726332390101011402012c")
+    assert len(compiled_program) == len(compiled_program_wo_information) + 15
+    # Read back interfaces
+    list_interfaces = get_interface_from_compiled_program(compiled_program)
+    print(list_interfaces)
+    assert list_interfaces == [1,20,300]
+    print(f"Success: the interfaces are : {list_interfaces}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is an extension of[ARC-23](https://github.com/algorandfoundation/ARCs/blob/main/ARCs/arc-0023.md) 

The idea is to use a bytecblock to add interfaces of an application at the end of a teal contract `arc29 XX YY ZZ`
