### PR TITLE
ubigint alias for byte[]

### DIFF
--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -531,7 +531,7 @@ For encoding purposes, the types are divided into two categories: static and dyn
 The dynamic types are:
 
 *  `<type>[]` for any `type`
-    * This includes `string` and `bigint` types since they are an alias for `byte[]`.
+    * This includes `string` and `bigint` types since they are aliases for `byte[]`.
 * `<type>[<N>]` for any dynamic `type`
 * `(T1,T2,...,TN)` if `Ti` is dynamic for some `1 <= i <= N`
 

--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -516,7 +516,7 @@ any leading zeros, _unless_ `N` is zero, in which case only a single 0 character
 * `address`: Used to represent a 32-byte Algorand address. This is equivalent to `byte[32]`.
 * `<type>[]`: A variable-length array. `type` can be any other type.
 * `string`: A variable-length byte array (`byte[]`) assumed to contain UTF-8 encoded content.
-* `bigint`: A variable-length byte array (`byte[]`) assumed to contain a variable-width unsigned integer.
+* `ubigint`: A variable-length byte array (`byte[]`) assumed to contain a variable-width unsigned integer.
 * `(T1,T2,…,TN)`: A tuple of the types `T1`, `T2`, …, `TN`, `N >= 1`.
 * reference types `account`, `asset`, `application`: **MUST NOT** be used as the return type.
 For encoding purposes they are an alias for `uint8`. See section "Reference Types" below.
@@ -531,7 +531,7 @@ For encoding purposes, the types are divided into two categories: static and dyn
 The dynamic types are:
 
 *  `<type>[]` for any `type`
-    * This includes `string` and `bigint` types since they are aliases for `byte[]`.
+    * This includes `string` and `ubigint` types since they are aliases for `byte[]`.
 * `<type>[<N>]` for any dynamic `type`
 * `(T1,T2,...,TN)` if `Ti` is dynamic for some `1 <= i <= N`
 
@@ -578,9 +578,11 @@ For any ABI value `x`, we recursively define `enc(x)` to be as follows:
     * `enc(x) = enc(x * 10^M)`, where `x * 10^M` is interpreted as a `uint<N>`.
 * If `x` is a boolean value `bool`:
     * `enc(x)` is a single byte whose **most significant bit** is either 1 or 0, if `x` is true or false respectively. All other bits are 0. Note: this means that a value of true will be encoded as `0x80` (`10000000` in binary) and a value of false will be encoded as `0x00`. This is in contrast to most other encoding schemes, where a value of true is encoded as `0x01`.
+* If `x` is a unsigned variable-width integer, `ubigint` 
+  * `enc(x)` is encoded as `byte[]` containing the big-endian encoding of `x`. `enc(x)` SHOULD be as succint as possible without 0-padding beyond the highest MSB set.
 
 Other aliased types' encodings are already covered:
-- `string` and `bigint` are aliases for `byte[]`
+- `string` is an alias for `byte[]`
 - `address` is an alias for `byte[32]`
 - `byte` is an alias for `uint8`
 - each of the reference types is an alias for `uint8`

--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -516,6 +516,7 @@ any leading zeros, _unless_ `N` is zero, in which case only a single 0 character
 * `address`: Used to represent a 32-byte Algorand address. This is equivalent to `byte[32]`.
 * `<type>[]`: A variable-length array. `type` can be any other type.
 * `string`: A variable-length byte array (`byte[]`) assumed to contain UTF-8 encoded content.
+* `bigint`: A variable-length byte array (`byte[]`) assumed to contain a variable-width unsigned integer.
 * `(T1,T2,…,TN)`: A tuple of the types `T1`, `T2`, …, `TN`, `N >= 1`.
 * reference types `account`, `asset`, `application`: **MUST NOT** be used as the return type.
 For encoding purposes they are an alias for `uint8`. See section "Reference Types" below.
@@ -530,7 +531,7 @@ For encoding purposes, the types are divided into two categories: static and dyn
 The dynamic types are:
 
 *  `<type>[]` for any `type`
-    * This includes `string` since it is an alias for `byte[]`.
+    * This includes `string` and `bigint` types since they are an alias for `byte[]`.
 * `<type>[<N>]` for any dynamic `type`
 * `(T1,T2,...,TN)` if `Ti` is dynamic for some `1 <= i <= N`
 
@@ -579,7 +580,8 @@ For any ABI value `x`, we recursively define `enc(x)` to be as follows:
     * `enc(x)` is a single byte whose **most significant bit** is either 1 or 0, if `x` is true or false respectively. All other bits are 0. Note: this means that a value of true will be encoded as `0x80` (`10000000` in binary) and a value of false will be encoded as `0x00`. This is in contrast to most other encoding schemes, where a value of true is encoded as `0x01`.
 
 Other aliased types' encodings are already covered:
-- `string` and `address` are aliases for `byte[]` and `byte[32]` respectively
+- `string` and `bigint` are aliases for `byte[]`
+- `address` is an alias for `byte[32]`
 - `byte` is an alias for `uint8`
 - each of the reference types is an alias for `uint8`
 


### PR DESCRIPTION
Adds a type alias `biging` for `byte[]` to represent variable-width integers