### PR TITLE
timestamp alias for uint64

### DIFF
--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -504,6 +504,7 @@ The following types are supported in the Algorand ABI.
 * `uint<N>`: An `N`-bit unsigned integer, where `8 <= N <= 512` and `N % 8 = 0`. When this type is
 used as part of a method signature, `N` must be written as a base 10 number without any leading zeros.
 * `byte`: An alias for `uint8`.
+* `timestamp`: An alias for `uint64` assumed to represent a Unix epoch timestamp
 * `bool`: A boolean value that is restricted to either 0 or 1. When encoded, up to 8 consecutive
 `bool` values will be packed into a single byte.
 * `ufixed<N>x<M>`: An `N`-bit unsigned fixed-point decimal number with precision `M`, where
@@ -581,6 +582,7 @@ For any ABI value `x`, we recursively define `enc(x)` to be as follows:
 Other aliased types' encodings are already covered:
 - `string` and `address` are aliases for `byte[]` and `byte[32]` respectively
 - `byte` is an alias for `uint8`
+- `timestamp` is an alias for `uint64`
 - each of the reference types is an alias for `uint8`
 
 #### Reference Types


### PR DESCRIPTION
`timestamp` alias for `uint64` for representing a unix epoch timestamp. 

Useful when inputting/returning data that interacts with `global LatestTimestamp`