### PR TITLE
ARC-36:  new metadata top-level field to support filters

### DIFF
--- a/ARCs/arc-0036.md
+++ b/ARCs/arc-0036.md
@@ -7,7 +7,7 @@ discussions-to: https://github.com/algorandfoundation/ARCs/issues/163
 status: Draft
 type: Standards Track
 category: ARC
-created: 2022-01-04
+created: 2023-03-10
 ---
 
 # Standard for declaring filters inside non-fungible token metadata

--- a/ARCs/arc-0036.md
+++ b/ARCs/arc-0036.md
@@ -44,7 +44,7 @@ The JSON schema for `filters` is as follows:
 
 The JSON schema for a `filter` is as follows:
 ```json
-interface Filter {
+{
   "filter": {
     "type": "object",
     "description": "Filter (attributes) that can be used to identify an nft. Values may be strings or numbers"
@@ -91,7 +91,7 @@ A standard for filters is needed so programs know what to expect in order to fil
 
 ## Backwards Compatibility
 
-If `filters` wants to be added on top of fields [ARC-16](arc-0016.md) `traits` and `filters` should be inside the `properties` object. (eg: [Example above](#Example-of-an-NFT-that-has-traits-&-filters))
+If `filters` wants to be added on top of fields [ARC-16](arc-0016.md) `traits` and `filters` should be inside the `properties` object. (eg: [Example above](arc-0036.md#example-of-an-nft-that-has-traits--filters))
 
 ## Security Considerations
 

--- a/ARCs/arc-0036.md
+++ b/ARCs/arc-0036.md
@@ -4,7 +4,8 @@ title: Convention for declaring filters of an NFT
 description: This is a convention for declaring filters in an NFT metadata
 author: Stéphane Barroso (@sudoweezy)
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/163
-status: Draft
+status: Last Call
+last-call-deadline: 2023-04-30
 type: Standards Track
 category: ARC
 created: 2023-03-10

--- a/ARCs/arc-0036.md
+++ b/ARCs/arc-0036.md
@@ -1,0 +1,102 @@
+---
+arc: 36
+title: Convention for declaring filters of an NFT
+description: This is a convention for declaring filters in an NFT metadata
+author: Stéphane Barroso (@sudoweezy)
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/163
+status: Draft
+type: Standards Track
+category: ARC
+created: 2022-01-04
+requires: 16
+---
+
+# Standard for declaring filters inside non-fungible token metadata
+
+## Abstract
+
+The goal is to establish a standard for how filters are declared inside a non-fungible (NFT) metadata.
+
+## Specification
+
+The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC-2119</a>.
+
+> Comments like this are non-normative.
+
+If the property `filters` is provided anywhere in the metadata of an nft, it **MUST** adhere to the schema below.
+If the nft is a part of a larger collection and that collection has filters, all the available filters for the collection **MUST** be listed as a property of the `filters` object.
+If the nft does not have a particular filter, it's value **MUST** be "none".
+
+The JSON schema for `filters` is as follows:
+
+```json
+{
+  "title": "Filters for Non-Fungible Token",
+  "type": "object",
+  "properties": {
+    "filters": {
+      "type": "array",
+      "description": "Filters can be used to filter nfts of a collection.  Values must be an array of filter."
+    }
+  }
+}
+```
+
+The JSON schema for a `filter` is as follows:
+```json
+interface Filter {
+  "filter": {
+    "type": "object",
+    "description": "Filter (attributes) that can be used to identify an nft. Values may be strings or numbers"
+  }
+}
+```
+
+#### Examples
+
+##### Example of an NFT that has traits & filters
+
+```json
+{
+  "name": "NFT With Traits & filters",
+  "description": "NFT with traits & filters",
+  "image": "https://s3.amazonaws.com/your-bucket/images/two.png",
+  "image_integrity": "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+  "properties": {
+    "creator": "Tim Smith",
+    "created_at": "January 2, 2022",
+    "traits": {
+      "background": "yellow",
+      "head": "curly"
+    },
+    "filters": [
+      {
+        "type": "range",
+        "name": "xp",
+        "value": 120
+      },
+      {
+        "type": "category",
+        "name": "dream state",
+        "value": "REM"
+      }
+    ]
+  }
+}
+```
+
+## Rationale
+
+A standard for filters is needed so programs know what to expect in order to filter things without using rarity.
+
+## Backwards Compatibility
+
+If `filters` wants to be added on top of fields [ARC-16](arc-0016.md) `traits` and `filters` should be inside the `properties` object. (eg: [Example above](#Example-of-an-NFT-that-has-traits-&-filters))
+
+## Security Considerations
+
+None.
+
+## Copyright
+
+Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.

--- a/ARCs/arc-0036.md
+++ b/ARCs/arc-0036.md
@@ -8,7 +8,6 @@ status: Draft
 type: Standards Track
 category: ARC
 created: 2022-01-04
-requires: 16
 ---
 
 # Standard for declaring filters inside non-fungible token metadata

--- a/ARCs/arc-0036.md
+++ b/ARCs/arc-0036.md
@@ -34,19 +34,9 @@ The JSON schema for `filters` is as follows:
   "type": "object",
   "properties": {
     "filters": {
-      "type": "array",
-      "description": "Filters can be used to filter nfts of a collection.  Values must be an array of filter."
+      "type": "object",
+      "description": "Filters can be used to filter nfts of a collection.  Values must be an array of strings or numbers."
     }
-  }
-}
-```
-
-The JSON schema for a `filter` is as follows:
-```json
-{
-  "filter": {
-    "type": "object",
-    "description": "Filter (attributes) that can be used to identify an nft. Values may be strings or numbers"
   }
 }
 ```
@@ -68,18 +58,10 @@ The JSON schema for a `filter` is as follows:
       "background": "yellow",
       "head": "curly"
     },
-    "filters": [
-      {
-        "type": "range",
-        "name": "xp",
-        "value": 120
-      },
-      {
-        "type": "category",
-        "name": "dream state",
-        "value": "REM"
-      }
-    ]
+    "filters": {
+      "xp": 120,
+      "state": "REM"
+    }
   }
 }
 ```
@@ -90,7 +72,7 @@ A standard for filters is needed so programs know what to expect in order to fil
 
 ## Backwards Compatibility
 
-If `filters` wants to be added on top of fields [ARC-16](arc-0016.md) `traits` and `filters` should be inside the `properties` object. (eg: [Example above](arc-0036.md#example-of-an-nft-that-has-traits--filters))
+If `filters` wants to be added on top of fields [ARC-16](./arc-0016.md) `traits` and `filters` should be inside the `properties` object. (eg: [Example above](./arc-0036.md#example-of-an-nft-that-has-traits--filters))
 
 ## Security Considerations
 


### PR DESCRIPTION
PR based on the discussion [Discussion for ARC-35: propose to add a new top-level field to support custom UI filters ](https://github.com/algorandfoundation/ARCs/issues/163)

Creators often want to define filterable custom attributes that do not impact NFT ranking. If filterable attributes were defined in a standardized way, frontends could provide filtering support on these attributes.

This change is backward compatible.

# Example of an NFT that has traits & filters

```json
{
  "name": "NFT With Traits & filters",
  "description": "NFT with traits & filters",
  "image": "https://s3.amazonaws.com/your-bucket/images/two.png",
  "image_integrity": "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
  "properties": {
    "creator": "Tim Smith",
    "created_at": "January 2, 2022",
    "traits": {
      "background": "yellow",
      "head": "curly"
    },
    "filters": {
      "xp": 120,
      "state": "REM"
    }
  }
}
```