### PR TITLE
ARC-75 Whitelisting of applications

### DIFF
--- a/ARCs/arc-0075.md
+++ b/ARCs/arc-0075.md
@@ -3,7 +3,7 @@ arc: 75
 title: Whitelisting of applications
 description: Standardized way for users to whitelist applications
 author: Joe POLNY (@joe-p), Stephane BARROSO (@SudoWeezy)
-discussions-to: <URL>
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/178
 status: Draft
 type: Standards Track
 category: ARC
@@ -13,21 +13,21 @@ created: 2023-05-16
 # Standardized way for users to whitelist applications 
 
 ## Abstract
-The goal is to allows an account to shows is will to dApps to be part of an application.
+The goal is to allow an account to show its will to dApps to be part of an application.
 
-If integrated into ecosystem technologies including wallets, epxlorers, and dApps, this standard can provide enhanced capabilities around Applications (eg [ARC-72](arc-0072.md)).
+If integrated into ecosystem technologies, including wallets, explorers, and dApps, this standard can provide enhanced capabilities around Applications (eg [ARC-72](arc-0072.md)).
 
 ## Motivation
-Algorand allows to store addresses inside an Application, however, this does not require any approval from related accounts.
+Algorand allows to store of addresses inside an Application. However, this does not require any approval from related accounts.
 
 This ARC allows dApps to know which application an account is willingly part of and wants to interact with.
 
 ## Specification
-The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC-2119</a>.
+The keywords "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC-2119</a>.
 
 ### TEAL Smart Contracts
 
-There are one smart contract being utilized: The [whitelist_registry](../assets/arc-0075/whitelist_registry.ts)
+There is one smart contract being utilized: The [whitelist_registry](../assets/arc-0075/whitelist_registry.ts)
 
 #### Registry
 
@@ -51,25 +51,23 @@ There are one smart contract being utilized: The [whitelist_registry](../assets/
 * App/box MBR funded by the creator (if deleting)
 
 ###### DELETE from Whitelist
-* Deletes box: `account` -> regristry ID
-* App.box MBR returned to regristry creator
+* Deletes box: `account` -> registry ID
+* App.box MBR returned to registry creator
 
 ###### DELETE Whitelist
-* Deletes regristry app
-* Deletes box: `account` -> regristry ID
-* App.box MBR returned to regristry creator
+* Deletes registry app
+* Deletes box: `account` -> registry ID
+* App.box MBR returned to registry creator
 
 ## Rationale
 This design was created to offer a standard mechanism by which wallets, explorers, and dapps could enable users to whitelist Applications without requiring any changes to the core protocol.  
 
 ## Reference Implementation
-An optional section that contains a reference/example implementation that people can use to assist in understanding or implementing this specification.  If the implementation is too large to reasonably be included inline, then consider adding it as one or more files in `../assets/arc-####/`.
-
 ### Source code
 * [ARC-75 TypeScript](../assets/arc-0075/whitelist_registry.ts)
 
 ## Security Considerations
-Even if an application is not whitelisted by an account, it does not prevent the same application to store the address of this account.
+Even if an account does not whitelist an application, it does not prevent the same application from storing the address of this account.
 
 ## Copyright
 Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.

--- a/ARCs/arc-0075.md
+++ b/ARCs/arc-0075.md
@@ -1,0 +1,75 @@
+---
+arc: 75
+title: Whitelisting of applications
+description: Standardized way for users to whitelist applications
+author: Joe POLNY (@joe-p), Stephane BARROSO (@SudoWeezy)
+discussions-to: <URL>
+status: Draft
+type: Standards Track
+category: ARC
+created: 2023-05-16
+---
+
+# Standardized way for users to whitelist applications 
+
+## Abstract
+The goal is to allows an account to shows is will to dApps to be part of an application.
+
+If integrated into ecosystem technologies including wallets, epxlorers, and dApps, this standard can provide enhanced capabilities around Applications (eg [ARC-72](arc-0072.md)).
+
+## Motivation
+Algorand allows to store addresses inside an Application, however, this does not require any approval from related accounts.
+
+This ARC allows dApps to know which application an account is willingly part of and wants to interact with.
+
+## Specification
+The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC-2119</a>.
+
+### TEAL Smart Contracts
+
+There are one smart contract being utilized: The [whitelist_registry](../assets/arc-0075/whitelist_registry.ts)
+
+#### Registry
+
+##### Storage
+
+| Type | Key     | Value          | Description                                  |
+| ---- | ------- | -------------- | -------------------------------------------- |
+| Box  | Account | Application ID | Applications' registry for the given account |
+
+##### Methods
+
+###### ADD to Whitelist
+* Creates/Add a registry for a given account
+* Creates box: `account` -> application ID
+* App/box MBR funded by the creator
+
+###### SET a Whitelist
+* Set a registry of `Applications' ID` for a given account
+* Creates/Delete box: `account` -> application ID
+* App/box MBR funded by the creator (if adding)
+* App/box MBR funded by the creator (if deleting)
+
+###### DELETE from Whitelist
+* Deletes box: `account` -> regristry ID
+* App.box MBR returned to regristry creator
+
+###### DELETE Whitelist
+* Deletes regristry app
+* Deletes box: `account` -> regristry ID
+* App.box MBR returned to regristry creator
+
+## Rationale
+This design was created to offer a standard mechanism by which wallets, explorers, and dapps could enable users to whitelist Applications without requiring any changes to the core protocol.  
+
+## Reference Implementation
+An optional section that contains a reference/example implementation that people can use to assist in understanding or implementing this specification.  If the implementation is too large to reasonably be included inline, then consider adding it as one or more files in `../assets/arc-####/`.
+
+### Source code
+* [ARC-75 TypeScript](../assets/arc-0075/whitelist_registry.ts)
+
+## Security Considerations
+Even if an application is not whitelisted by an account, it does not prevent the same application to store the address of this account.
+
+## Copyright
+Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.

--- a/assets/arc-0075/whitelist_registry.ts
+++ b/assets/arc-0075/whitelist_registry.ts
@@ -1,0 +1,114 @@
+/* eslint-disable no-undef */
+/* eslint-disable class-methods-use-this */
+
+import { Contract } from '../../src/lib/index';
+
+// eslint-disable-next-line no-unused-vars
+class WhitelistApplicationRegistry extends Contract {
+  whitelist = new BoxMap<[Account, uint16], uint64[]>({ defaultSize: 10 });
+
+  @createApplication
+  create(): void {}
+
+  private verifyMBRPayment(payment: PayTxn, preMBR: uint64): void {
+    assert(payment.amount === this.app.address.minBalance - preMBR);
+    assert(payment.receiver === this.app.address);
+  }
+
+  private sendMBRPayment(preMBR: uint64): void {
+    sendPayment({
+      sender: this.app.address,
+      receiver: this.txn.sender,
+      amount: preMBR - this.app.address.minBalance,
+      fee: 0,
+    });
+  }
+
+  /**
+   * Add collection to whitelist box
+   *
+   * @param id - The id of the senders's whitelist to add the collection to
+   * @param collection - The app ID of the contract for the collection
+   * @param payment - The payment transaction to cover the MBR change
+   *
+   */
+  addToWhiteList(id: uint16, collection: uint64, payment: PayTxn): void {
+    const preMBR = this.app.address.minBalance;
+    const key: [Account, uint16] = [this.txn.sender, id];
+
+    if (this.whitelist.exists(key)) {
+      const whitelist = this.whitelist.get(key);
+      this.whitelist.delete(key);
+
+      whitelist.push(collection);
+      this.whitelist.put(key, whitelist);
+    } else {
+      const whitelist: uint64[] = [collection];
+      this.whitelist.put(key, whitelist);
+    }
+
+    this.verifyMBRPayment(payment, preMBR);
+  }
+
+  /**
+   * Sets a collection whitelist for the sender. Should only be used when adding/removing
+   * more than one collection
+   *
+   * @param id - The id of the sender's whitelist to set
+   * @param collections - Array of app IDs that signify the whitelisted collections
+   *
+   */
+  setWhitelist(id: uint16, collections: uint64[]): void {
+    const preMBR = this.app.address.minBalance;
+    const key: [Account, uint16] = [this.txn.sender, id];
+
+    this.whitelist.delete(key);
+
+    this.whitelist.put(key, collections);
+
+    if (preMBR > this.app.address.minBalance) {
+      this.sendMBRPayment(preMBR);
+    } else {
+      this.verifyMBRPayment(this.txnGroup[this.txn.groupIndex - 1], preMBR);
+    }
+  }
+
+  /**
+   * Deletes a collection whitelist for the sender
+   *
+   * @param id - The id of the sender's whitelist to delete
+   *
+   */
+  deleteWhitelist(id: uint16): void {
+    const preMBR = this.app.address.minBalance;
+    const key: [Account, uint16] = [this.txn.sender, id];
+
+    this.whitelist.delete(key);
+
+    this.sendMBRPayment(preMBR);
+  }
+
+  /**
+   * Deletes a collection from a whitelist for the sender
+   *
+   * @param id - The id of the sender's whitelist to delete from
+   * @param collection - The app ID of the contract for the collection
+   * @param index - The index of the collection in the whitelist
+   *
+   */
+  deleteFromWhitelist(id: uint16, collection: uint64, index: uint64): void {
+    const preMBR = this.app.address.minBalance;
+    const key: [Account, uint16] = [this.txn.sender, id];
+
+    const whitelist = this.whitelist.get(key);
+    this.whitelist.delete(key);
+
+    const spliced = whitelist.splice(index, 1);
+
+    this.whitelist.put(key, whitelist);
+
+    assert(spliced[0] === collection);
+
+    this.sendMBRPayment(preMBR);
+  }
+}


### PR DESCRIPTION
This follows the discussion about ARC-72 NFT Application and the need for users to allow or not the display of Application NFT collections

It is extended to any kind of application.

Algorand allows the storage of addresses inside an Application. However, this does not require any approval from related accounts.

The goal is to allow an account to show its will to dApps to be part of an application.