### PR TITLE
ARC-4: Update ClearState behavior and revert change to tuple limits

### DIFF
--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -266,10 +266,32 @@ from method invocations.
 
 The primary purpose of bare Application calls is to allow the
 execution of an OnCompletion (`apan`) action which requires no
-inputs and has no return value. A Contract **MAY** allow this
-for all OnCompletion actions, for only a subset of them, or for
-none at all. Great care should be taken when allowing these
-operations.
+inputs and has no return value. A Contract **MAY** allow this for
+all of the OnCompletion actions listed below, for only a subset of
+them, or for none at all. Great care should be taken when allowing
+these operations.
+
+Allowed OnCompletion actions:
+* 0: NoOp
+* 1: OptIn
+* 2: CloseOut
+* 4: UpdateApplication
+* 5: DeleteApplication
+
+Note that OnCompletion action 3, ClearState, is **NOT** allowed to
+be invoked as a bare Application call.
+
+> While ClearState is a valid OnCompletion action, its behavior differs
+> significantly from the other actions. Namely, an Application running during
+> ClearState which wishes to have any effect on the state of the chain
+> must never fail, since due to the unique behavior about ClearState
+> failure, doing so would revert any effect made by that Application.
+> Because of this, Applications running during ClearState are
+> incentivized to never fail. Accepting any user input, whether that
+> is an ABI method selector, method arguments, or even relying on the
+> absence of Application arguments to indicate a bare Application call,
+> is therefore a dangerous operation, since there is no way to enforce
+> properties or even presence about data that is supplied by the user.
 
 If a Contract elects to allow bare Application calls for some
 OnCompletion actions, then that Contract **SHOULD** also allow
@@ -290,12 +312,21 @@ action. Rather, the Contract should have one or more methods that
 are meant to be called with the appropriate OnCompletion action set
 in order to process that action.
 
+A Contract **MUST NOT** allow any of its methods to be called with the
+ClearState OnCompletion action.
+
+> To reinforce an earlier point, it is unsafe for a ClearState program
+> to read any user input, whether that is a method argument or even
+> relying on a certain method selector to be present. This behavior
+> makes it unsafe to use ABI calling conventions during ClearState.
+
 If an Application is called with greater than zero Application call
-arguments (**NOT** a bare Application call), the Application **MUST**
+arguments (i.e. **NOT** a bare Application call) and the OnCompletion
+action is **NOT** ClearState, the Application **MUST**
 always treat the first argument as a method selector and invoke
-the specified method, regardless of the OnCompletion action of
-the Application call. This applies to Application creation
-transactions as well, where the supplied Application ID is 0.
+the specified method. This behavior **MUST** be followed for all
+OnCompletion actions, except for ClearState. This applies to Application
+creation transactions as well, where the supplied Application ID is 0.
 
 Similar to OnCompletion actions, if a Contract requires its
 creation transaction to take inputs or to return a value, then
@@ -385,6 +416,9 @@ implementation (callee) must agree on how information will be passed
 to and from the method. This ABI defines a standard for where this
 information should be stored and for its format.
 
+This standard does not apply to Application calls with the ClearState
+OnCompletion action, since it is unsafe for ClearState programs to rely
+on user input.
 
 #### Standard Format
 
@@ -517,7 +551,7 @@ any leading zeros, _unless_ `N` is zero, in which case only a single 0 character
 * `address`: Used to represent a 32-byte Algorand address. This is equivalent to `byte[32]`.
 * `<type>[]`: A variable-length array. `type` can be any other type.
 * `string`: A variable-length byte array (`byte[]`) assumed to contain UTF-8 encoded content.
-* `(T1,T2,…,TN)`: A tuple of the types `T1`, `T2`, …, `TN`, `N >= 1`.
+* `(T1,T2,…,TN)`: A tuple of the types `T1`, `T2`, …, `TN`, `N >= 0`.
 * reference types `account`, `asset`, `application`: **MUST NOT** be used as the return type.
 For encoding purposes they are an alias for `uint8`. See section "Reference Types" below.
 


### PR DESCRIPTION
This PR makes two changes to ARC-4:
1. Revises how the ClearState OnCompletion action is handled with respect to ABI methods and bare app calls. We discovered in PyTeal that supporting ABI methods and bare app calls in clear state programs is actually a dangerous operation, since it introduces failure points to the clear state program (e.g. what if an unsupported method is called?). This was corrected in https://github.com/algorand/pyteal/issues/638, and we want to bring this change to ARC-4 as well.
2. Reverts a previous change which disallowed empty tuple types, e.g. `()`.