### PR TITLE
nit(arc-9): fix links & spelling

### DIFF
--- a/ARCs/arc-0009.md
+++ b/ARCs/arc-0009.md
@@ -14,7 +14,7 @@ created: 2021-08-09
 
 ## Abstract
 
-Functions `getAlgodv2Client` and `getIndexerClient` which return a `BaseHTTPClient` that can be used to construct an `Algodv2Client` and an `IndexerClient` respectively (from the <a href="https://github.com/algorand/js-algorand-sdk/blob/develop/src/main.ts">JS SDK</a>);
+Functions `getAlgodv2Client` and `getIndexerClient` which return a `BaseHTTPClient` that can be used to construct an `Algodv2Client` and an `IndexerClient` respectively (from the <a href="https://github.com/algorand/js-algorand-sdk/blob/develop/src/client/baseHTTPClient.ts">JS SDK</a>);
 
 ## Specification
 
@@ -24,7 +24,7 @@ Functions `getAlgodv2Client` and `getIndexerClient` which return a `BaseHTTPClie
 type GetAlgodv2ClientFunction = () => Promise<BaseHTTPClient>
 ```
 
-Returns a promised `BaseHTTPClient` that can be used to then build an `Algodv2Client`, where `BaseHTTPClient` is an interface matching the interface `algosdk.BaseHTTPClient` from the <a href="https://github.com/algorand/js-algorand-sdk/blob/develop/src/main.ts">JS SDK</a>).
+Returns a promised `BaseHTTPClient` that can be used to then build an `Algodv2Client`, where `BaseHTTPClient` is an interface matching the interface `algosdk.BaseHTTPClient` from the <a href="https://github.com/algorand/js-algorand-sdk/blob/develop/src/client/baseHTTPClient.ts">JS SDK</a>).
 
 ### Interface `GetIndexerClientFunction`
 
@@ -32,7 +32,7 @@ Returns a promised `BaseHTTPClient` that can be used to then build an `Algodv2Cl
 type GetIndexerClientFunction = () => Promise<BaseHTTPClient>
 ```
 
-Returns a promised `BaseHTTPClient` that can be used to then build an `Indexer`, where `BaseHTTPClient` is an interface matching the interface `algosdk.BaseHTTPClient` from the <a href="https://github.com/algorand/js-algorand-sdk/blob/develop/src/main.ts">JS SDK</a>).
+Returns a promised `BaseHTTPClient` that can be used to then build an `Indexer`, where `BaseHTTPClient` is an interface matching the interface `algosdk.BaseHTTPClient` from the <a href="https://github.com/algorand/js-algorand-sdk/blob/develop/src/client/baseHTTPClient.ts">JS SDK</a>).
 
 ### Security considerations
 
@@ -51,8 +51,8 @@ In case the wallet uses an API service that is secret or provided by the user, t
 
 ## Rationale
 
-Nontrivial DApps often require the ability to query the network for activity. Algorand DApps written without regard to wallets are likely written using `Algodv2` and `Indexer` from `algosdk`. 
-This document allows DApps to instantiate `Algodv2` and `Indexer` fom a wallet API service, making it easy for JavaScript DApp authors to port their code to work with wallets.
+Nontrivial dApps often require the ability to query the network for activity. Algorand dApps written without regard to wallets are likely written using `Algodv2` and `Indexer` from `algosdk`. 
+This document allows dApps to instantiate `Algodv2` and `Indexer` for a wallet API service, making it easy for JavaScript dApp authors to port their code to work with wallets.
 
 ## Security Considerations
 


### PR DESCRIPTION
This fixes the links to the base http client & some spelling mistakes.