### PR TITLE
fix(arc-6): TS definitions are not valid TS

### DIFF
--- a/ARCs/arc-0006.md
+++ b/ARCs/arc-0006.md
@@ -47,26 +47,26 @@ export type EnableOpts = (
   EnableNetworkOpts & EnableAccountsOpts
 );
 
-export interface EnableNetworkOpts = {
+export interface EnableNetworkOpts {
   genesisID?: string;
   genesisHash?: GenesisHash;
 };
 
-export interface EnableAccountsOpts = {
+export interface EnableAccountsOpts {
   accounts?: AlgorandAddress[];
 };
 
 
 export type EnableResult = (
-  EnablNetworkResult & EnableAccountsResult
+  EnableNetworkResult & EnableAccountsResult
 );
 
-export interface EnableNetworkResult = {
+export interface EnableNetworkResult {
   genesisID: string;
   genesisHash: GenesisHash;
 }
 
-export interface EnableAccountsResult = {
+export interface EnableAccountsResult {
   accounts: AlgorandAddress[];
 }
 


### PR DESCRIPTION
* `EnablNetworkOpts` -> `EnableNetworkOpts`: missing e
* TypeScript definitions were not actually valid, interface declaration shouldn't have = 