### PR TITLE
ARC-0076 - Password Account

### DIFF
--- a/ARCs/arc-0076.md
+++ b/ARCs/arc-0076.md
@@ -23,10 +23,10 @@ This standard seek the synchronization between wallets which may provide passwor
 Hash of the seed bytes is calculated with algorithm:
 
 ```
-const init = `${data}`;
+const init = `ARC-76-${data}-999-SHA512/256`;
 let hash = sha512.sha512_256.hex(init);
 for (let i = 1; i <= 997; i++) {
-  hash = sha512.sha512_256.hex(hash);
+  hash = sha512.sha512_256.hex(`ARC-76-${hash}`);
 }
 const bytes = sha512.sha512_256.array(hash);
 
@@ -42,7 +42,7 @@ Length of the data section SHOULD be at least 16 bytes long.
 Email H999 account is account generated from the original data
 
 ```
-let init = `${email}-${password}`;
+let init = `ARC-76-${email}-${password}-999-SHA512/256`;
 ```
 
 The email part can be published to the service provider backend and verified by the service provider. Password MUST NOT be transfered over the network.

--- a/ARCs/arc-0076.md
+++ b/ARCs/arc-0076.md
@@ -26,9 +26,6 @@ Seed bytes generation is calculated with algorithm:
       const init = `ARC-0076-${password}-{slotId}-PBKDF2-999999`;
       const salt = `ARC-0076-{slotId}-PBKDF2-999999`;
       const iterations = 999999;
-      if (!window || !window.crypto || !window.crypto.subtle) {
-        throw Error("Crypto API in browser is not available");
-      }
       const cryptoKey = await window.crypto.subtle.importKey(
         "raw",
         Buffer.from(init, "utf-8"),

--- a/ARCs/arc-0076.md
+++ b/ARCs/arc-0076.md
@@ -66,6 +66,24 @@ The email part can be published to the service provider backend and verified by 
 
 Length of the password SHOULD be at least 16 bytes long.
 
+### Sample data
+This sample data may be used for verification of the ARC-0076 implementation.
+
+```
+const email = "email@example.com";
+const password = "12345678901234567890123456789012345678901234567890";
+const slotId = "0";
+const init = `ARC-0076-${email}-${password}-{slotId}-PBKDF2-999999`;
+const salt = `ARC-0076-${email}-{slotId}-PBKDF2-999999`;
+```
+
+Results in: 
+
+```
+masterBits = [225,7,139,154,245,210,181,138,188,129,145,53,246,184,243,88,163,163,109,208,77,71,7,235,81,244,129,215,102,168,105,21]
+account.addr = "5AHWQJ5D52K4GRW4JWQ5GMR53F7PDSJEGT4PXVFSBQYE7VXDVG3WSPWSBM"
+```
+
 ## Rationale
 This standard was designed to allow the wallets to provide password protected accounts which does not require general population to store the mnemonic. Email extension allows service providers to bind specific account with the email address, and user experience to feel the basic authentication form with email and password they are already used to from web2 usecases.
 

--- a/ARCs/arc-0076.md
+++ b/ARCs/arc-0076.md
@@ -4,7 +4,8 @@ title: Password Account
 description: Password account using PBKDF2
 author: Ludovit Scholtz (@scholtz)
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/208
-status: Draft
+status: Last Call
+last-call-deadline: 2023-07-15
 type: Standards Track
 category: Core
 created: 2023-06-12

--- a/ARCs/arc-0076.md
+++ b/ARCs/arc-0076.md
@@ -67,7 +67,7 @@ The email part can be published to the service provider backend and verified by 
 Length of the password SHOULD be at least 16 bytes long.
 
 ### Sample data
-This sample data may be used for verification of the ARC-0076 implementation.
+This sample data may be used for verification of the ```ARC-0076``` implementation.
 
 ```
 const email = "email@example.com";

--- a/ARCs/arc-0076.md
+++ b/ARCs/arc-0076.md
@@ -1,0 +1,65 @@
+---
+arc: 76
+title: H999 Account
+description: SHA512-256 999 account
+author: Ludovit Scholtz (@scholtz)
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/203
+status: Draft
+type: Standards Track
+category: Account
+created: 2023-06-12
+requires: 
+---
+
+## Abstract
+This standard specifies a computation for seed bytes for H999 account. For general adoption it is better for people to remember passphrase than mnemonic. With this standard person can hash the passphrase and receive the seed bytes for X25529 algorand account.
+
+## Motivation
+By providing a clear and precise computation process, H999 account empowers individuals to effortlessly obtain their seed bytes for algorand account. In the realm of practicality and widespread adoption, the standard highlights the immense advantages of utilizing a passphrase rather than a mnemonic. Remembering a passphrase becomes the key to unlocking a world of possibilities. With this groundbreaking standard, individuals can take control of their X25529 Algorand account by simply hashing their passphrase and effortlessly receiving the corresponding seed bytes. It's time to embrace this new era of accessibility and security, empowering yourself to reach new heights in the world of H999 accounts. Let this standard serve as your guiding light, motivating community to embark on a journey of limitless possibilities and unparalleled success.
+
+This standard seek the synchronization between wallets which may provide password protected accounts.
+
+## Specification
+
+Hash of the seed bytes is calculated with algorithm:
+
+```
+const init = `${data}`;
+let hash = sha512.sha512_256.hex(init);
+for (let i = 1; i <= 997; i++) {
+  hash = sha512.sha512_256.hex(hash);
+}
+const bytes = sha512.sha512_256.array(hash);
+
+const uint8 = new Uint8Array(bytes);
+const mnemonic = algosdk.mnemonicFromSeed(uint8);
+const genAccount = algosdk.mnemonicToSecretKey(mnemonic);
+```
+
+Length of the data section SHOULD be at least 16 bytes long.
+
+### Email Password account
+
+Email H999 account is account generated from the original data
+
+```
+let init = `${email}-${password}`;
+```
+
+The email part can be published to the service provider backend and verified by the service provider. Password MUST NOT be transfered over the network.
+
+Length of the password SHOULD be at least 12 bytes long.
+
+## Rationale
+This standard was designed to allow the wallets to provide password protected accounts which does not require general population to store the mnemonic. Email extension allows service providers to bind specific account with the email address, and user experience to feel the basic authentication form with email and password they are already used to from web2 usecases.
+
+## Backwards Compatibility
+We expect future extensions to be compatibile with H999 account.
+
+## Security Considerations
+This standard moves the security of strength of the account to how user generates the password.
+
+This standard relies on randomness  and collision resistance of results of SHA512/256. User MUST be informed about the risks associated with this type of account.
+
+## Copyright
+Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.

--- a/ARCs/arc-0076.md
+++ b/ARCs/arc-0076.md
@@ -3,12 +3,11 @@ arc: 76
 title: H999 Account
 description: SHA512-256 999 account
 author: Ludovit Scholtz (@scholtz)
-discussions-to: https://github.com/algorandfoundation/ARCs/issues/203
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/208
 status: Draft
 type: Standards Track
-category: Account
+category: Core
 created: 2023-06-12
-requires: 
 ---
 
 ## Abstract

--- a/ARCs/arc-0076.md
+++ b/ARCs/arc-0076.md
@@ -1,7 +1,7 @@
 ---
 arc: 76
-title: H999 Account
-description: SHA512-256 999 account
+title: Password Account
+description: Password account using PBKDF2
 author: Ludovit Scholtz (@scholtz)
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/208
 status: Draft
@@ -11,54 +11,74 @@ created: 2023-06-12
 ---
 
 ## Abstract
-This standard specifies a computation for seed bytes for H999 account. For general adoption it is better for people to remember passphrase than mnemonic. With this standard person can hash the passphrase and receive the seed bytes for X25529 algorand account.
+This standard specifies a computation for seed bytes for Password Account. For general adoption it is better for people to remember passphrase than mnemonic. With this standard person can hash the passphrase and receive the seed bytes for X25529 algorand account.
 
 ## Motivation
-By providing a clear and precise computation process, H999 account empowers individuals to effortlessly obtain their seed bytes for algorand account. In the realm of practicality and widespread adoption, the standard highlights the immense advantages of utilizing a passphrase rather than a mnemonic. Remembering a passphrase becomes the key to unlocking a world of possibilities. With this groundbreaking standard, individuals can take control of their X25529 Algorand account by simply hashing their passphrase and effortlessly receiving the corresponding seed bytes. It's time to embrace this new era of accessibility and security, empowering yourself to reach new heights in the world of H999 accounts. Let this standard serve as your guiding light, motivating community to embark on a journey of limitless possibilities and unparalleled success.
+By providing a clear and precise computation process, Password Account empowers individuals to effortlessly obtain their seed bytes for algorand account. In the realm of practicality and widespread adoption, the standard highlights the immense advantages of utilizing a passphrase rather than a mnemonic. Remembering a passphrase becomes the key to unlocking a world of possibilities. With this groundbreaking standard, individuals can take control of their X25529 Algorand account by simply hashing their passphrase and effortlessly receiving the corresponding seed bytes. It's time to embrace this new era of accessibility and security, empowering yourself to reach new heights in the world of Password Accounts. Let this standard serve as your guiding light, motivating community to embark on a journey of limitless possibilities and unparalleled success.
 
 This standard seek the synchronization between wallets which may provide password protected accounts.
 
 ## Specification
 
-Hash of the seed bytes is calculated with algorithm:
+Seed bytes generation is calculated with algorithm:
 
 ```
-const init = `ARC-76-${data}-999-SHA512/256`;
-let hash = sha512.sha512_256.hex(init);
-for (let i = 1; i <= 997; i++) {
-  hash = sha512.sha512_256.hex(`ARC-76-${hash}`);
-}
-const bytes = sha512.sha512_256.array(hash);
+      const init = `ARC-0076-${password}-{slotId}-PBKDF2-999999`;
+      const salt = `ARC-0076-{slotId}-PBKDF2-999999`;
+      const iterations = 999999;
+      if (!window || !window.crypto || !window.crypto.subtle) {
+        throw Error("Crypto API in browser is not available");
+      }
+      const cryptoKey = await window.crypto.subtle.importKey(
+        "raw",
+        Buffer.from(init, "utf-8"),
+        "PBKDF2",
+        false,
+        ["deriveBits", "deriveKey"]
+      );
+      const masterBits = await window.crypto.subtle.deriveBits(
+        {
+          name: "PBKDF2",
+          hash: "SHA-256",
+          salt: Buffer.from(salt, "utf-8"),
+          iterations: iterations,
+        },
+        cryptoKey,
+        256
+      );
 
-const uint8 = new Uint8Array(bytes);
-const mnemonic = algosdk.mnemonicFromSeed(uint8);
-const genAccount = algosdk.mnemonicToSecretKey(mnemonic);
+      const uint8 = new Uint8Array(masterBits);
+      const mnemonic = algosdk.mnemonicFromSeed(uint8);
+      const genAccount = algosdk.mnemonicToSecretKey(mnemonic);
 ```
 
 Length of the data section SHOULD be at least 16 bytes long.
 
+Slot ID is account iteration. Default is "0".
+
 ### Email Password account
 
-Email H999 account is account generated from the original data
+Email Password account is account generated from the original data
 
 ```
-let init = `ARC-76-${email}-${password}-999-SHA512/256`;
+      const init = `ARC-0076-${email}-${password}-{slotId}-PBKDF2-999999`;
+      const salt = `ARC-0076-${email}-{slotId}-PBKDF2-999999`;
 ```
 
 The email part can be published to the service provider backend and verified by the service provider. Password MUST NOT be transfered over the network.
 
-Length of the password SHOULD be at least 12 bytes long.
+Length of the password SHOULD be at least 16 bytes long.
 
 ## Rationale
 This standard was designed to allow the wallets to provide password protected accounts which does not require general population to store the mnemonic. Email extension allows service providers to bind specific account with the email address, and user experience to feel the basic authentication form with email and password they are already used to from web2 usecases.
 
 ## Backwards Compatibility
-We expect future extensions to be compatibile with H999 account.
+We expect future extensions to be compatibile with Password account. The hash mechanism for the future algorighms should be suffixed such as ```-PBKDF2-999999```.
 
 ## Security Considerations
 This standard moves the security of strength of the account to how user generates the password.
 
-This standard relies on randomness  and collision resistance of results of SHA512/256. User MUST be informed about the risks associated with this type of account.
+This standard relies on randomness  and collision resistance of PBKDF2 and 'SHA-256'. User MUST be informed about the risks associated with this type of account.
 
 ## Copyright
 Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.


### PR DESCRIPTION
This standard specifies a computation for seed bytes for H999 account. For general adoption it is better for people to remember passphrase than mnemonic. With this standard person can hash the passphrase and receive the seed bytes for X25529 algorand account.