### PR TITLE
ARC-0014 Algorand authentication using signed transaction

### DIFF
--- a/ARCs/arc-0014.md
+++ b/ARCs/arc-0014.md
@@ -1,6 +1,6 @@
 ---
 arc: 14
-title: Algorand authentication using signed transaction
+title: Algorand authentication
 description: Algorand authentication using signed transaction.
 author: Ludovit Scholtz (@scholtz)
 discussions-to: https://github.com/algorandfoundation/ARCs/pull/218
@@ -73,22 +73,29 @@ Service MUST return 401 response if the token data cannot be parsed to Algorand 
 Service MUST return 401 response if the signed transaction has invalid signature.
 
 ### Realm
-
 The realm is the text message in the note field of the transaction. The realm MUST end with ```#ARC14``` postfix.
 
 ### ARC 14 compatible wallet
-
 ARC 14 compatible wallet is wallet which clearly differenciate between signing standard transaction and signing authentication transaction.
 
 ARC 14 compatible wallet MUST show full realm without the postfix  ```#ARC14```.
 
 ### Rekeying
-
 ARC 14 backend service MUST be able to check for the rekeying of an address. If account has been rekeyed to another address, only valid signature from the rekeyed address can return valid authorized resource.
 
 ### Multisig
-
 ARC 14 backend service MUST be able to handle the multisig accounts. The valid threshold and signatures from the authorized address must be met to return valid authorized resource.
+
+## Rationale
+This standard was designed to allow the api backend services authorize resources when they have information that user has access to the private key of the account or multisig threshold of signators are able to sign the request.
+
+## Backwards Compatibility
+We expect future updates of this standard to be backward compatible.
+
+## Security Considerations
+This standard is moving forward the authentication using signed transactions as the signing of arbitrary bytes by accounts is not supported by wallets. 
+
+The risk arise when people gets used to sign authentication transaction and malicious web can give them to sign the transaction to spend the assets. The ARC 14 compatible wallets standard has been made to fight this risk as the wallets which will implement this standard will notify user about making authorization transaction and not payment transaction. This will do marketing for wallets which will be ARC 14 compatible first and will not do harm to usability of this standard.
 
 ## Copyright
 Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.

--- a/ARCs/arc-0014.md
+++ b/ARCs/arc-0014.md
@@ -75,16 +75,16 @@ Service MUST return 401 response if the signed transaction has invalid signature
 ### Realm
 The realm is the text message in the note field of the transaction. The realm MUST end with ```#ARC14``` postfix.
 
-### ARC 14 compatible wallet
-ARC 14 compatible wallet is wallet which clearly differenciate between signing standard transaction and signing authentication transaction.
+### ARC-0014 compatible wallet
+ARC-0014 compatible wallet is wallet which clearly differenciate between signing standard transaction and signing authentication transaction.
 
-ARC 14 compatible wallet MUST show full realm without the postfix  ```#ARC14```.
+ARC-0014 compatible wallet MUST show full realm without the postfix  ```#ARC14```.
 
 ### Rekeying
-ARC 14 backend service MUST be able to check for the rekeying of an address. If account has been rekeyed to another address, only valid signature from the rekeyed address can return valid authorized resource.
+ARC-0014 backend service MUST be able to check for the rekeying of an address. If account has been rekeyed to another address, only valid signature from the rekeyed address can return valid authorized resource.
 
 ### Multisig
-ARC 14 backend service MUST be able to handle the multisig accounts. The valid threshold and signatures from the authorized address must be met to return valid authorized resource.
+ARC-0014 backend service MUST be able to handle the multisig accounts. The valid threshold and signatures from the authorized address must be met to return valid authorized resource.
 
 ## Rationale
 This standard was designed to allow the api backend services authorize resources when they have information that user has access to the private key of the account or multisig threshold of signators are able to sign the request.
@@ -95,7 +95,7 @@ We expect future updates of this standard to be backward compatible.
 ## Security Considerations
 This standard is moving forward the authentication using signed transactions as the signing of arbitrary bytes by accounts is not supported by wallets. 
 
-The risk arise when people gets used to sign authentication transaction and malicious web can give them to sign the transaction to spend the assets. The ARC 14 compatible wallets standard has been made to fight this risk as the wallets which will implement this standard will notify user about making authorization transaction and not payment transaction. This will do marketing for wallets which will be ARC 14 compatible first and will not do harm to usability of this standard.
+The risk arise when people gets used to sign authentication transaction and malicious web can give them to sign the transaction to spend the assets. The ARC-0014 compatible wallets standard has been made to fight this risk as the wallets which will implement this standard will notify user about making authorization transaction and not payment transaction. This will do marketing for wallets which will be ARC-0014 compatible first and will not do harm to usability of this standard.
 
 ## Copyright
 Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.

--- a/ARCs/arc-0014.md
+++ b/ARCs/arc-0014.md
@@ -3,7 +3,7 @@ arc: 14
 title: Algorand authentication using signed transaction
 description: Algorand authentication using signed transaction.
 author: Ludovit Scholtz (@scholtz)
-discussions-to: https://github.com/algorandfoundation/ARCs/issues/208
+discussions-to: https://github.com/algorandfoundation/ARCs/pull/218
 status: Draft
 type: Standards Track
 category: ARC
@@ -28,7 +28,7 @@ Base64 is the standard described in [RFC-4648](https://www.ietf.org/rfc/rfc4648.
 
 ## Request for comments
 
-Please comment or suggest pull request for this document here: [https://github.com/scholtz/AMS/issues](https://github.com/scholtz/AMS/issues)
+Please comment or suggest pull request for this document here: https://github.com/algorandfoundation/ARCs/pull/218
 
 ### Authentication
 
@@ -76,19 +76,19 @@ Service MUST return 401 response if the signed transaction has invalid signature
 
 The realm is the text message in the note field of the transaction. The realm MUST end with ```#ARC14``` postfix.
 
-### ARC14 compatible wallet
+### ARC 14 compatible wallet
 
-ARC14 compatible wallet is wallet which clearly differenciate between signing standard transaction and signing authentication transaction.
+ARC 14 compatible wallet is wallet which clearly differenciate between signing standard transaction and signing authentication transaction.
 
-ARC14 compatible wallet MUST show full realm without the postfix  ```#ARC14```.
+ARC 14 compatible wallet MUST show full realm without the postfix  ```#ARC14```.
 
 ### Rekeying
 
-ARC14 backend service MUST be able to check for the rekeying of an address. If account has been rekeyed to another address, only valid signature from the rekeyed address can return valid authorized resource.
+ARC 14 backend service MUST be able to check for the rekeying of an address. If account has been rekeyed to another address, only valid signature from the rekeyed address can return valid authorized resource.
 
 ### Multisig
 
-ARC14 backend service MUST be able to handle the multisig accounts. The valid threshold and signatures from the authorized address must be met to return valid authorized resource.
+ARC 14 backend service MUST be able to handle the multisig accounts. The valid threshold and signatures from the authorized address must be met to return valid authorized resource.
 
 ## Copyright
 Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.

--- a/ARCs/arc-0014.md
+++ b/ARCs/arc-0014.md
@@ -3,7 +3,7 @@ arc: 14
 title: Algorand authentication
 description: Algorand authentication using signed transaction.
 author: Ludovit Scholtz (@scholtz)
-discussions-to: https://github.com/algorandfoundation/ARCs/pull/218
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/221
 status: Draft
 type: Standards Track
 category: ARC
@@ -23,10 +23,6 @@ The goal of this standard is to define authorization process and authentication 
 The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in RFC-2119.
 
 Base64 is the standard described in RFC-4648.
-
-## Request for comments
-
-Please comment or suggest pull request for this document here: https://github.com/algorandfoundation/ARCs/pull/218
 
 ### Authentication
 

--- a/ARCs/arc-0014.md
+++ b/ARCs/arc-0014.md
@@ -12,19 +12,17 @@ created: 2021-11-09
 
 # Algorand Standard for authentication
 
-## Summary
-
-This document introduces the standard for authentication using the algorand accounts with signed transactions.
-
 ## Abstract
+
+This document introduces the standard for authentication using the algorand accounts with signed transactions - [ARC-0014](arc-0014.md).
 
 The goal of this standard is to define authorization process and authentication procedures for communication between web application and backend services or between two backend services. 
 
 ## Specification
 
-The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in [RFC-2119](https://www.ietf.org/rfc/rfc2119.txt).
+The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in RFC-2119.
 
-Base64 is the standard described in [RFC-4648](https://www.ietf.org/rfc/rfc4648.txt).
+Base64 is the standard described in RFC-4648.
 
 ## Request for comments
 

--- a/ARCs/arc-0014.md
+++ b/ARCs/arc-0014.md
@@ -1,0 +1,94 @@
+---
+arc: 14
+title: Algorand authentication using signed transaction
+description: Algorand authentication using signed transaction.
+author: Ludovit Scholtz (@scholtz)
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/208
+status: Draft
+type: Standards Track
+category: ARC
+created: 2021-11-09
+---
+
+# Algorand Standard for authentication
+
+## Summary
+
+This document introduces the standard for authentication using the algorand accounts with signed transactions.
+
+## Abstract
+
+The goal of this standard is to define authorization process and authentication procedures for communication between web application and backend services or between two backend services. 
+
+## Specification
+
+The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in [RFC-2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+Base64 is the standard described in [RFC-4648](https://www.ietf.org/rfc/rfc4648.txt).
+
+## Request for comments
+
+Please comment or suggest pull request for this document here: [https://github.com/scholtz/AMS/issues](https://github.com/scholtz/AMS/issues)
+
+### Authentication
+
+Authentication is process in which person generates the authorization token for communication with backend service.
+
+Token MUST be generated from Algorand public and private key - from algorand address.
+
+In the first step of the authentication, the message to be signed is generated. The message MUST contain note field with configurable Realm. Realm is identifier of the service. It MAY be the web address of the service for intended purpose.
+
+The message MUST be self signed - the receiver is the same as the sender.
+
+The message MUST have network parameters filled in. The network genesis hash SHOULD be configured for validation pursposes by backend service. The latest block is the time of expiration of the token. The latest block MUST be provided.
+
+In the second step, the message MUST be signed by the account private key.
+
+The message MUST not be submitted to the network (mainnet, testnet) nor should be published in any other way. It may be used only for communcation to the backend service.
+
+### Authorization
+
+Authorization determines what resources a user can access.
+
+Authorization is the process of validating authorization token by the backend application and allowing the account permissions to the backend services.
+
+Authorization token SHOULD be send to backend service using the authorization header.
+
+Header data MUST start with prefix "SigTx "
+
+Authorization message must follow prefix in Base64 encoding.
+
+Example of the HTTP header:
+
+```
+Authorization: SigTx gqNzaWfEQJ4FWNWiXuRz5DKu1RYL5qHlR+iP/3qW4BF+pPD/ok20tJSqBICQn2jWysFD88W3a0ojEBM+IWvh5tyfvZyZ+AKjdHhuiaNmZWXNA+iiZnbOAQx8LaNnZW6sdGVzdG5ldC12MS4womdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJsds4BDIAVpG5vdGXEEURSRU0tQXV0aGVudGljYXRlo3JjdsQgG1z5khU3SjAofF/H7uWij05Nzy1ZVn2sYVEzIHauIAWjc25kxCAbXPmSFTdKMCh8X8fu5aKPTk3PLVlWfaxhUTMgdq4gBaR0eXBlo3BheQ==
+```
+
+Service MUST return 401 response if the service is configured to check for validity of the expiration of the token and the current block at the specified network is higher. Service SHOULD be configured to check for validity of the expiration of the token.
+
+Service MUST return 401 response if the token data is not Base64 valid data.
+
+Service MUST return 401 response if the token data cannot be parsed to Algorand signed transaction.
+
+Service MUST return 401 response if the signed transaction has invalid signature.
+
+### Realm
+
+The realm is the text message in the note field of the transaction. The realm MUST end with ```#ARC14``` postfix.
+
+### ARC14 compatible wallet
+
+ARC14 compatible wallet is wallet which clearly differenciate between signing standard transaction and signing authentication transaction.
+
+ARC14 compatible wallet MUST show full realm without the postfix  ```#ARC14```.
+
+### Rekeying
+
+ARC14 backend service MUST be able to check for the rekeying of an address. If account has been rekeyed to another address, only valid signature from the rekeyed address can return valid authorized resource.
+
+### Multisig
+
+ARC14 backend service MUST be able to handle the multisig accounts. The valid threshold and signatures from the authorized address must be met to return valid authorized resource.
+
+## Copyright
+Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.


### PR DESCRIPTION
arc-0014 back to life

Following https://github.com/algorandfoundation/ARCs/pull/41

and https://github.com/algorandfoundation/ARCs/issues/42

ARC14 is widely used for example in these projects:

- https://www.nuget.org/packages/AlgorandAuthentication
- https://github.com/scholtz/AlgorandAuthenticationDotNet
- https://github.com/scholtz/AlgorandKMDServer
- https://kmd.h3.a-wallet.net/swagger/index.html
- https://github.com/scholtz/HasuraAlgorandAuthWebHook
- https://github.com/scholtz/Algorand2FAMultisig
- https://2fa-docs.a-wallet.net/
- https://2famsig.k8s.aramid.finance/swagger/index.html
- https://github.com/scholtz/wallet
- https://github.com/scholtz/AlgorandPublicData/

Newly it has full support for rekeying and multisig.