### PR TITLE
Adding arc number prefix to Application's method name

### DIFF
--- a/ARCs/arc-0000.md
+++ b/ARCs/arc-0000.md
@@ -206,6 +206,7 @@ eg:
       "args": [
         { "type": "uint64", "name": "Number", "desc": "A number" },
       ]
+    },
     {
       "name": "arc0_Event2",
       "desc": "Method 2",

--- a/ARCs/arc-0000.md
+++ b/ARCs/arc-0000.md
@@ -165,9 +165,9 @@ To provide information about which ARCs has been implemented on a particular app
 > Where <ARC number> represents the specific ARC number associated with the implemented requirement change.
 
 eg:
-'''json
+```json
 {
-  "name": "ARC0",
+  "name": "Naming convention",
   "desc": "Example",
   "methods": [
     {
@@ -189,8 +189,6 @@ eg:
   ]
 }
 ```
-
-'''
 
 ## Rationale
 

--- a/ARCs/arc-0000.md
+++ b/ARCs/arc-0000.md
@@ -160,6 +160,37 @@ References to other ARCs should follow the format `ARC-N`, where `N` is the ARC 
 
 Images, diagrams, and auxiliary files should be included in a subdirectory of the `assets` folder for that ARC as follows: `assets/arc-N` (where **N** is to be replaced with the ARC number). When linking to an image in the ARC, use relative links such as `../assets/arc-1/image.png`.
 
+### Application's Methods name
+To provide information about which ARCs has been implemented on a particular application, namespace with the ARC number should be used before every method name: `arc<ARC number>_MethodName`.
+
+eg:
+'''json
+{
+  "name": "ARC0",
+  "desc": "Example",
+  "methods": [
+    {
+      "name": "arc0_method1",
+      "desc": "Method 1",
+      "args": [
+        { "type": "uint64", "name": "Number", "desc": "A number" },
+      ],
+      "returns": { "type": "void[]" }
+    },
+    {
+      "name": "arc0_method2",
+      "desc": "Method 2",
+      "args": [
+        { "type": "byte[]", "name": "user_data", "desc": "Some characters" }
+      ],
+      "returns": { "type": "void[]" }
+    }
+  ]
+}
+```
+
+'''
+
 ## Rationale
 
 This document was derived heavily from <a href="https://github.com/ethereum/eips">Ethereum's EIP-1</a>, which was written by Martin Becze and Hudson Jameson, which in turn was derived from  <a href="https://github.com/bitcoin/bips">Bitcoin's BIP-0001</a> written by Amir Taaki, which in turn was derived from <a href="https://www.python.org/dev/peps/">Python's PEP-0001</a>. In many places, text was copied and modified. Although the PEP-0001 text was written by Barry Warsaw, Jeremy Hylton, and David Goodger, they are not responsible for its use in the Algorand Request for Comments. They should not be bothered with technical questions specific to Algorand or the ARC. Please direct all comments to the ARC editors.

--- a/ARCs/arc-0000.md
+++ b/ARCs/arc-0000.md
@@ -161,13 +161,13 @@ References to other ARCs should follow the format `ARC-N`, where `N` is the ARC 
 Images, diagrams, and auxiliary files should be included in a subdirectory of the `assets` folder for that ARC as follows: `assets/arc-N` (where **N** is to be replaced with the ARC number). When linking to an image in the ARC, use relative links such as `../assets/arc-1/image.png`.
 
 ### Application's Methods name
-To provide information about which ARCs has been implemented on a particular application, namespace with the ARC number should be used before every method name: `arc<ARC number>_MethodName`.
-> Where <ARC number> represents the specific ARC number associated with the implemented requirement change.
+To provide information about which ARCs has been implemented on a particular application, namespace with the ARC number should be used before every method name: `arc<ARC number>_methodName`.
+> Where <ARC number> represents the specific ARC number associated to the standard.
 
 eg:
 ```json
 {
-  "name": "Naming convention",
+  "name": "Method naming convention",
   "desc": "Example",
   "methods": [
     {
@@ -185,6 +185,33 @@ eg:
         { "type": "byte[]", "name": "user_data", "desc": "Some characters" }
       ],
       "returns": { "type": "void[]" }
+    }
+  ]
+}
+```
+
+### Application's Event name
+To provide information about which ARCs has been implemented on a particular application, namespace with the ARC number should be used before every [ARC-73](./arc-0073.md) event name: `arc<ARC number>_EventName`.
+> Where <ARC number> represents the specific ARC number associated to the standard.
+
+eg:
+```json
+{
+  "name": "Event naming convention",
+  "desc": "Example",
+  "events": [
+    {
+      "name": "arc0_Event1",
+      "desc": "Method 1",
+      "args": [
+        { "type": "uint64", "name": "Number", "desc": "A number" },
+      ]
+    {
+      "name": "arc0_Event2",
+      "desc": "Method 2",
+      "args": [
+        { "type": "byte[]", "name": "user_data", "desc": "Some characters" }
+      ]
     }
   ]
 }

--- a/ARCs/arc-0000.md
+++ b/ARCs/arc-0000.md
@@ -162,6 +162,7 @@ Images, diagrams, and auxiliary files should be included in a subdirectory of th
 
 ### Application's Methods name
 To provide information about which ARCs has been implemented on a particular application, namespace with the ARC number should be used before every method name: `arc<ARC number>_MethodName`.
+> Where <ARC number> represents the specific ARC number associated with the implemented requirement change.
 
 eg:
 '''json


### PR DESCRIPTION
There is a need to provide information about which ARCs have been implemented within a particular application. To address this requirement, it is proposed to introduce a standardized namespace for each implemented ARC number to be used before every method name.