### PR TITLE
ARC45: gtxn ABI Encoding

### DIFF
--- a/ARCs/arc-0045.md
+++ b/ARCs/arc-0045.md
@@ -1,9 +1,9 @@
 ---
-arc: <to be assigned>
+arc: 45
 title: gtxn ABI Encoding
 description: Introduces a new, more flexible, encoding for referencing other transactions in the group
 author: Joe Polny (@joe-p)
-discussions-to: <URL>
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/220
 status: Draft
 type: Standards Track
 category: ARC


### PR DESCRIPTION
Introduces a new, more flexible, encoding for referencing other transactions in the group