### PR TITLE
ARC-34 Update Threshold

### DIFF
--- a/ARCs/arc-0034.md
+++ b/ARCs/arc-0034.md
@@ -39,11 +39,11 @@ The voting system for the xGov program will be the following:
 In order for a proposal to be approved, it is necessary for the number of votes in favor of the proposal to be proportionate to the amount of funds requested. This ensures that the allocation of funds is in line with the community's consensus and in accordance with democratic principles.
 
 The formula to calculate the voting power needed to pass a proposal is as follows:
-`Voting Power Needed = (Amount Requested) / (Amount Available) * (Total Number Of Algo In Term Pools)`
+`Voting Power Needed = (Amount Requested) / (Amount Available) * (Total Number Of Remaining Eligible Algo In Term Pools at End of Voting Period)`
 
-> eg. 2 000 000 Algo are available to be given away as grants, 200 000 000 millions Algo rewards are committed to the xGov Process (200 000 000 votes available in the Term Pools):
+> eg. 2 000 000 Algo are available to be given away as grants, 200 000 000 millions Algo rewards are committed to the xGov Process (200 000 000 votes available in the Term Pools). Out of the 200 000 000 votes, only 100 000 000 have remained eligible at the time the voting period ended (e.g. half voters forgot to vote and thus became ineligible):
 > - Proposal A request 100 000 Algos (5 % of the Amount available)
-> - Proposal A needs 5 % of the votes (10 000 000 Votes) to go through
+> - Proposal A needs 5 % of the remaining eligible votes (5 000 000 Votes) to go through
 
 ### Life of a proposal
 The proposal process will follow steps below:


### PR DESCRIPTION
With the current calculation of the threshold for whether a proposal gathered sufficient number of votes to be approved, it is possible that a large portion of funds end up undistributed if any voters forget to cast their votes since their votes still count towards the total. Moreover, voters that did not vote become ineligible in the xGov program but their Algo remains in the Term Pool. Therefore, only the part of the votes that belong to xGovs still eligible at the end of the voting period should count towards the threshold (similarly as is with regular Governance and the cool down period).