### PR TITLE
ARC-48 Improving flexibility 

### DIFF
--- a/ARCs/arc-0048.md
+++ b/ARCs/arc-0048.md
@@ -10,23 +10,27 @@ created: 2023-07-19
 ---
 
 ## Abstract
-The Targeted DeFi Rewards is a temporary incentive program that distributes ALGO to be deployed in targeted activities to attract new DeFi users from within and outside the ecosystem. 
+The Targeted DeFi Rewards is a temporary incentive program that distributes Algo to be deployed in targeted activities to attract new DeFi users from within and outside the ecosystem. 
 The goal is to give DeFi projects more flexibility in how these rewards are structured and distributed among their user base, targeting rapid growth, deeper DEX liquidity, and incentives for users who come to Algorand in the middle of a governance period.
 
 ## Specification
-The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC-2119</a>.
+The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in <a href="https://www.ietf.org/rfc/rfc2119.txt" target=_blank>RFC-2119</a>.
 
 ### Eligibility Criteria
 
 To be eligible to apply to this program, projects must abide by the <a href="https://www.algorand.foundation/disclaimers">Disclaimers</a> (in particular the “Excluded Jurisdictions” section) and be willing to enter into a binding contract in the form of the template provided by the Algorand Foundation.
 
-Projects must have at least 500K ALGO equivalent in TVL of white-listed assets, as calculated on June 23, 2023.
+> The Algorand Foundation is temporarily allowing US-based entities to apply for this program. Approved projects will have their rewards swapped to USDCa on the day of the payment. This exception will be reviewed periodically.
 
-The DeFi Advisory Committee will review applications to verify each TVL claim, thus ensuring that claims are valid prior to application approval.
+Projects must have at least 500K Algo equivalent in TVL of white-listed assets, at the time of the quarterly snapshot block, which happens on the 15th day of the last month of each calendar quarter. All related wallet addresses will be provided in advance for peer scrutiny.
+
+The DeFi Advisory Committee will review applications to verify each TVL claim, thus ensuring that claims are valid prior to application approval. 
 
 For AMMs we will leverage the Eligible Liquidity Pool list that is currently adopted to allow the governors commitment of LP tokens in the DeFi Rewards program, with extension to the assets defined below.
 
-For Lending/Borrowing protocols, each project will provide a list of their assets and their holding wallet address(es), which will be provided in advance for scrutiny.
+For Lending/Borrowing protocols, each project will provide a list of their assets and their holding wallet address(es).
+
+For Bridges, each project will provide a list of the bridged assets and their holding wallet address(es).
 
 ### Assets Selection
 
@@ -45,29 +49,27 @@ The following assets are qualified and meet the above criteria:
 - gALGO - ASA ID 793124631
 - USDC - ASA ID 31566704
 - USDT - ASA ID 312769
-- STBL2 - ASA ID 841126810
 - goBTC - ASA ID 386192725
 - goETH - ASA ID 386195940
 - PLANETS - ASA ID 27165954
-- GARD - ASA ID 684649988
 - OPUL - ASA ID 287867876
 - VESTIGE - ASA ID 700965019
 - CHIPS - ASA ID 388592191
 - DEFLY - ASA ID 470842789
-- BANK - ASA ID 900652777
 - goUSD - ASA 672913181
 - WBTC - ASA 1058926737
 - WETH - ASA 887406851
 - GOLD$ - ASA 246516580  
 - SILVER$ - ASA 246519683
 - PEPE - ASA 1096015467
-- COOP - ASA 796425061 
+- COOP - ASA 796425061
+- GORA - ASA 1138500612
 
-> Applications for the above ASA white list for Governance Period 8 are now closed.  
+> Applications for the above list can be submitted at any time <a href="https://forms.gle/kpEpZ8sih69M5xa39">using this form</a>. Cut off for the applications review is the 7th day of the last month of each calendar quarter, or one week before the quarterly snapshot date. 
 
 ### Rewards Distribution
 
-Projects will receive 11250 ALGO for each 500K ALGO TVL as defined above, rounded down. In the event that 5MM ALGO are not sufficient for all the projects, ALGO rewards will be distributed to each protocol based on their weighted contribution of TVL to Algorand DeFi. 
+Projects will receive 11250 Algo for each 500K Algo TVL as defined above, rounded down. In the event that the available Algo are not sufficient for all the projects, Algo rewards will be distributed to each protocol based on their weighted contribution of TVL to Algorand DeFi. 
 
 Rewards per project are capped at 25% of the total rewards distributed under this program for that period.  In the event of partial distribution of the allocated 7.5MM, the remaining funds will be distributed as regular DeFi governance rewards. For Governance Period 8, the AMM TVL count has doubled, when compared to lending/borrow and bridge projects, in recognition of their strategic role in providing liquidity for the ecosystem. This modification was approved by the DeFi Committee.
 

--- a/ARCs/arc-0048.md
+++ b/ARCs/arc-0048.md
@@ -71,8 +71,7 @@ Projects will receive 11250 ALGO for each 500K ALGO TVL as defined above, rounde
 
 Rewards per project are capped at 25% of the total rewards distributed under this program for that period.  In the event of partial distribution of the allocated 7.5MM, the remaining funds will be distributed as regular DeFi governance rewards. For Governance Period 8, the AMM TVL count has doubled, when compared to lending/borrow and bridge projects, in recognition of their strategic role in providing liquidity for the ecosystem. This modification was approved by the DeFi Committee.
 
-Rewards under this program will be distributed to projects within 4 weeks of the scheduled start date of the new governance period and the project(s) must distribute the totality of the amount received as incentives to their users, with at least 95% of rewards distributed by the end of the period and the remainder distributed in the following period. The methodology for payment must be made public and approved by the Algorand DeFi advisory committee prior to distribution.
-
+Rewards under this program will be distributed to projects within 4 weeks of the scheduled start date of the new governance period and the project(s). The usage of these rewards will be made public, and they will be entirely dedicated to protocol provision, user rewards, and user engagement. The use of rewards and methodology for payment must be made public and approved by the Algorand DeFi advisory committee prior to distribution.
 
 ## Rationale
 This document was versionned using google doc, it made more sense to move it on github.


### PR DESCRIPTION
Improving the Measure (ARC48) to propose for the community to allow more flexibility on DEFI priorities. 
The projects would then be able to reward users and work on user acquisition. 

It is an improvement to reduce admin burden and economically insignificant (smaller) reward amounts. And, all rewards utilisation will be disclosed to the community in whole (publicly and timely) and, wholly devoted to protocol provision, user rewards, user engagement.