### PR TITLE
Update ARC-32: Update to match current implementation used by Beaker and algokit-utils

### DIFF
--- a/ARCs/arc-0032.md
+++ b/ARCs/arc-0032.md
@@ -132,9 +132,9 @@ type CallConfigSpec = {
 
 ### Hints specification
 
-Contains supplemental information about ARC-0004 ABI methods, each record represents a single method in the ARC-0004 contract. The record key should be the corresponding ABI signature.
+Contains supplemental information about [ARC-0004](https://arc.algorand.foundation/ARCs/arc-0022) ABI methods, each record represents a single method in the [ARC-0004](https://arc.algorand.foundation/ARCs/arc-0022) contract. The record key should be the corresponding ABI signature.
 
-NOTE: Ideally this information would be part of the ARC-0004 ABI specification.
+NOTE: Ideally this information would be part of the [ARC-0004](https://arc.algorand.foundation/ARCs/arc-0022) ABI specification.
 
 ```ts
 type HintSpec = {  

--- a/ARCs/arc-0032.md
+++ b/ARCs/arc-0032.md
@@ -44,9 +44,6 @@ type AppSpec = {
   source?: SourceSpec;
   // the schema this application requires/provides
   schema?: SchemaSpec;  
-  
-  // map of pc=>error message
-  errors?: ErrorSpec;
 
   // supplemental information for calling bare methods
   bare_call_config?: CallConfigSpec;
@@ -112,32 +109,6 @@ type ReservedSchemaValueSpec = {
   max_keys: number;
 }
 
-```
-
-### Error Specification
-
-TODO: Provide a reference implementation of this
-TODO: number as key will fail in certain places, lets do something else?
-
-The Error specification contains a mapping of `PC` (or `Program counter` TODO: Link to description) to a human readable string that describes the error condition.  
-
-When a node returns a logic eval error, the `pc` specified in the error message should be looked up in the ErrorSpec map to find the relevant error message.
-
-```ts
-// TODO: more complex spec for errors? what else would we want? 
-type ErrorMsg = string;
-type ErrorSpec = Record<number, ErrorMsg>;
-```
-
-To build an error spec, compile the source teal program with its source map, and map the `PC` of any `assert` or `err` opcodes with a comment on the immediately preceding line into the `ErrorSpec` map. 
-
-ex: the following will produce an entry in the error spec like `{..., 10: "// Sorry but 2 is not less than 1", ...}` assuming the `PC` of the `assert` op is 10.
-```
-int 1    
-int 2
-<
-// Sorry but 2 is not less than 1
-assert
 ```
 
 ### Bare call configuration

--- a/ARCs/arc-0032.md
+++ b/ARCs/arc-0032.md
@@ -38,23 +38,31 @@ The Application Specification is composed of a number of elements that serve to 
 ```ts
 type AppSpec = {
   // embedded contract fields, see ARC-0004 for more
-  ABIContract;
+  contract: ARC4Contract;
+  
   // the original teal source, containing annotations, base64 encoded
   source?: SourceSpec;
   // the schema this application requires/provides
-  schema?: SchemaSpec;
-  // map of type name=>user defined type
-  types?: TypeSpec;
+  schema?: SchemaSpec;  
+  
   // map of pc=>error message
   errors?: ErrorSpec;
+
+  // supplemental information for calling bare methods
+  bare_call_config?: CallConfigSpec;
+  // supplemental information for calling ARC-0004 ABI methods
+  hints: HintsSpec;
+  // storage requirements
+  state?: StateSpec;  
 }
 ```
+
 ### Source Specification
 
 Contains the source TEAL files including comments and other annotations.
 
 ```ts
-// Opject containing the original TEAL source files
+// Object containing the original TEAL source files
 type SourceSpec = {
   // b64 encoded approval program
   approval: string;
@@ -106,75 +114,9 @@ type ReservedSchemaValueSpec = {
 
 ```
 
-### Type Specification
-
-TODO: rename `userdefinedtype` to something else, user is not a great name for it. custom type? 
-
-
-Each user defined type is specified as either an array of `StructElement`s or an `ABIType`. 
-
-If an array of `StructElement`s is provided, the `UserDefinedType` is treated as a Tuple with named fields.  The ABI encoding is exactly as if an ABI Tuple type defined the same element types in the same order.  It is important to encode the struct elements as an array since it preserves the order of fields which is critical to encoding/decoding the data properly.
-
-If a single ABIType is provided, the `UserDefinedType` is treated as a Type Alias and can be encoded or decoded as the `ABIType` directly.
-
-```ts
-// Type aliases for readability
-type FieldName = string;
-type ABIType = string;
-
-// Each field in the struct contains a name and ABI type
-type StructElement = [FieldName, ABIType];
-
-// Type aliases for readability
-type UserDefinedType = StructElement[] | ABIType;
-type UserDefinedTypeName = string;
-
-// A map of type name to either a list of struct fields or a single ABI type 
-type TypeSpec = Record<UserDefinedTypeName, UserDefinedType>
-```
-
-For example a `UserDefinedType` that should provide an array of `StructElement`s
-
-Given the PyTeal:
-```py
-from pyteal import abi
-
-class Thing(abi.NamedTuple):
-  addr: abi.Field[abi.address]
-  balance: abi.Field[abi.Uint64]
-```
-the equivalent ABI type is `(address,uint64)` and an element in the TypeSpec is:
-
-```js
-{
-// ...
-"Thing":[["addr", "address"]["balance","uint64"]],
-// ...
-}
-```
-
-An example `UserDefinedType` that is a simple type alias:
-
-```py
-from typing import Literal
-from pyteal import abi
-
-HashDigest = abi.StaticBytes[Literal[32]]
-
-```
-
-Produces the following entry in the `TypeSpec`
-```js
-{
-  // ...
-  "HashDigest":"bytes[32]",
-  // ...
-}
-```
-
-
 ### Error Specification
 
+TODO: Provide a reference implementation of this
 TODO: number as key will fail in certain places, lets do something else?
 
 The Error specification contains a mapping of `PC` (or `Program counter` TODO: Link to description) to a human readable string that describes the error condition.  
@@ -198,21 +140,148 @@ int 2
 assert
 ```
 
-### Default Argument
+### Bare call configuration
 
+Describes the supported OnComplete actions for bare calls on the contract.
+
+```ts
+// describes under what conditions an associated OnCompletion type can be used with a particular method
+// NEVER: Never handle the specified on completion type
+// CALL: Only handle the specified on completion type for application calls
+// CREATE: Only handle the specified on completion type for application create calls
+// ALL: Handle the specified on completion type for both create and normal application calls
+type CallConfig = 'NEVER' | 'CALL' | 'CREATE' | 'ALL'
+
+type CallConfigSpec = {
+    // lists the supported CallConfig for each on completion type, if not specified a CallConfig of NEVER is assumed
+    no_op?: CallConfig
+    opt_in?: CallConfig
+    close_out?: CallConfig
+    update_application?: CallConfig
+    delete_application?: CallConfig    
+}
+```
+
+### Hints specification
+
+Contains supplemental information about ARC-0004 ABI methods, each record represents a single method in the ARC-0004 contract. The record key should be the corresponding ABI signature.
+
+NOTE: Ideally this information would be part of the ARC-0004 ABI specification.
+
+```ts
+type HintSpec = {  
+  // indicates the method has no side-effects and can be call via dry-run/simulate
+  read_only?: bool;
+  // describes the structure of arguments, key represents the argument name
+  structs?: Record<string, StructSpec>;
+  // describes source of default values for arguments, key represents the argument name
+  default_arguments?: Record<string, DefaultArgumentSpec>;
+  // describes which OnCompletion types are supported
+  call_config: CallConfigSpec;
+}
+
+// key represents the method signature for an ABI method defined in 'contracts'
+type HintsSpec = Record<string, HintSpec>
+```
+
+#### Readonly Specification
+
+TODO:
+
+#### Struct Specification
+
+Each defined type is specified as an array of `StructElement`s. 
+
+The ABI encoding is exactly as if an ABI Tuple type defined the same element types in the same order. 
+It is important to encode the struct elements as an array since it preserves the order of fields which is critical to encoding/decoding the data properly.
+
+```ts
+// Type aliases for readability
+type FieldName = string
+// string encoded datatype name defined in ARC-0004
+type ABIType = string
+
+// Each field in the struct contains a name and ABI type
+type StructElement = [FieldName, ABIType]
+// Type aliases for readability
+type ContractDefinedType = StructElement[]
+type ContractDefinedTypeName = string;
+
+// represents a input/output structure
+type StructSpec = {
+  name: ContractDefinedTypeName
+  elements: ContractDefinedType
+}
+```
+
+For example a `ContractDefinedType` that should provide an array of `StructElement`s
+
+Given the PyTeal:
+```py
+from pyteal import abi
+
+class Thing(abi.NamedTuple):
+  addr: abi.Field[abi.address]
+  balance: abi.Field[abi.Uint64]
+```
+the equivalent ABI type is `(address,uint64)` and an element in the TypeSpec is:
+
+```js
+{
+// ...
+"Thing":[["addr", "address"]["balance","uint64"]],
+// ...
+}
+```
+
+#### Default Argument
+
+Defines how default argument values can be obtained.
+
+TODO: describe when/how this can be used
 TODO: this should probably be proposed in a separate ARC like the `read-only` attr?
 
 ```ts
+// ARC-0004 ABI method definition
+type ABIMethod = {};
 
-type DefaultArgumentSource = "global-state" | "local-state" | "abi-method" | "constant";
-export type DefaultArgument = {
+type DefaultArgumentSpec = {
   // Where to look for the default arg value 
-  source: DefaultArgumentSource;
-  // extra data to include when looking up the value (key for state, actual data for constant)
-  data: string | bigint | number;
+  // constant: a constant value as specified in data
+  // global-state: from global state using the key specified in data
+  // local-state: from local state using the key specified in data  
+  // abi-method: via the specified ABIMethod in data
+  source: "constant" | "global-state" | "local-state" | "abi-method"
+  // extra data to include when looking up the value
+  data: string | bigint | number | ABIMethod
+}
+```
+
+### State Specifications
+
+Describes the total storage requirements for both global and local storage, this should include both declared and reserved described in SchemaSpec.
+
+NOTE: If the Schema specification contained additional information such that the size could be calculated, then this specification would not be required.
+
+```ts
+type StateSchema = {
+  // how many byte slices are required
+  num_byte_slices: number
+  // how many uints are required
+  num_uints: number
 }
 
+type StateSpec = {
+  // schema specification for global storage
+  global: StateSchema
+  // schema specification for local storage
+  local: StateSchema
+}
 ```
+
+### Reference schema
+
+A full JSON schema for application.json can be found in [../asserts/arc-0032/application.schema.json](../assets/arc-0032/application.schema.json).
 
 ## Rationale
 The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages.
@@ -224,7 +293,9 @@ All ARCs that introduce backwards incompatibilities must include a section descr
 Test cases for an implementation are mandatory for ARCs that are affecting consensus changes.  If the test suite is too large to reasonably be included inline, then consider adding it as one or more files in `../assets/arc-####/`.
 
 ## Reference Implementation
-An optional section that contains a reference/example implementation that people can use to assist in understanding or implementing this specification.  If the implementation is too large to reasonably be included inline, then consider adding it as one or more files in `../assets/arc-####/`.
+[algokit-utils-py](https://github.com/algorandfoundation/algokit-utils-py/blob/main/src/algokit_utils/application_specification.py) and [algokit-utils-ts](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts) both provide reference implementations for the specification structure and using the data in an `ApplicationClient` ([Python](https://github.com/algorandfoundation/algokit-utils-py/blob/main/src/algokit_utils/application_client.py) | [TypeScript](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app-client.ts))
+
+[Beaker](https://github.com/algorand-devrel/beaker/blob/master/beaker/application.py#L1098C9-L1098C14) provides a reference implementation for creating an application.json from a smart contract.
 
 ## Security Considerations
 All ARCs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. ARC submissions missing the "Security Considerations" section will be rejected. An ARC cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.

--- a/ARCs/arc-0032.md
+++ b/ARCs/arc-0032.md
@@ -70,9 +70,6 @@ type SourceSpec = {
 
 ### Schema Specification
 
-TODO: describe diff between Declared/Reserved and motivation for providing both
-TODO: describe how to decode the type and the value given the decoded type
-
 The schema of an application is critical to know prior to creation since it is immutable after create. It also helps clients of the application understand the data that is available to be queried from off chain. Individual fields can be referenced from the [default argument](#default-argument) to provide input data to a given ABI method.
 
 While some fields are possible to know ahead of time, others may be keyed dynamically. In both cases the data type being stored MUST be known and declared ahead of time. 

--- a/ARCs/arc-0032.md
+++ b/ARCs/arc-0032.md
@@ -27,8 +27,8 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 - [Application Specification](#application-specification): The object containing the elements describing the Application.
 - [Source Specification](#source-specification): The object containing a description of the TEAL source programs that are evaluated when this Application is called.
 - [Schema Specification](#schema-specification): The object containing a description of the schema required by the Application.
-- [Type Specification](#type-specification): The object containing a map type name of name to the user defined data types
-- [Error Specification](#error-specification): The object containing a map of `pc` to Error message
+- [Bare Call Specification](#bare-call-specification): The object containing a map of on completion actions to allowable calls for bare methods
+- [Hints Specification](#hints-specification): The object containing a map of method signatures to meta data about each method
 
 
 ### Application Specification
@@ -108,7 +108,7 @@ type ReservedSchemaValueSpec = {
 
 ```
 
-### Bare call configuration
+### Bare call specification
 
 Describes the supported OnComplete actions for bare calls on the contract.
 

--- a/ARCs/arc-0032.md
+++ b/ARCs/arc-0032.md
@@ -13,7 +13,7 @@ requires: 4, 21
 
 ## Abstract
 
-An Application is partially defined by it's [methods](arc-0004.md) but further information about the Application should be available.  Other descriptive elements of an application may include it's State Schema, the original TEAL source programs, default method arguments, and custom data types.  This specification defines the descriptive elements of an Application that should be available to clients to provide useful information for an Application Client.
+An Application is partially defined by it's [methods](./arc-0004.md) but further information about the Application should be available.  Other descriptive elements of an application may include it's State Schema, the original TEAL source programs, default method arguments, and custom data types.  This specification defines the descriptive elements of an Application that should be available to clients to provide useful information for an Application Client.
 
 ## Motivation
 
@@ -132,9 +132,9 @@ type CallConfigSpec = {
 
 ### Hints specification
 
-Contains supplemental information about [ARC-0004](https://arc.algorand.foundation/ARCs/arc-0022) ABI methods, each record represents a single method in the [ARC-0004](https://arc.algorand.foundation/ARCs/arc-0022) contract. The record key should be the corresponding ABI signature.
+Contains supplemental information about [ARC-0004](./arc-0004.md) ABI methods, each record represents a single method in the [ARC-0004](./arc-0004.md) contract. The record key should be the corresponding ABI signature.
 
-NOTE: Ideally this information would be part of the [ARC-0004](https://arc.algorand.foundation/ARCs/arc-0022) ABI specification.
+NOTE: Ideally this information would be part of the [ARC-0004](./arc-0004.md) ABI specification.
 
 ```ts
 type HintSpec = {  
@@ -156,7 +156,7 @@ type HintsSpec = Record<string, HintSpec>
 
 Indicates the method has no side-effects and can be called via dry-run/simulate
 
-NOTE: This property is made obsolete by [ARC-0022](https://arc.algorand.foundation/ARCs/arc-0022) but is included as it is currently
+NOTE: This property is made obsolete by [ARC-0022](./arc-0022.md) but is included as it is currently
 used by existing reference implementations such as Beaker
 
 #### Struct Specification
@@ -259,7 +259,7 @@ type StateSpec = {
 
 ### Reference schema
 
-A full JSON schema for application.json can be found in [../asserts/arc-0032/application.schema.json](../assets/arc-0032/application.schema.json).
+A full JSON schema for application.json can be found in [here](../assets/arc-0032/application.schema.json).
 
 ## Rationale
 The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages.
@@ -271,9 +271,9 @@ All ARCs that introduce backwards incompatibilities must include a section descr
 Test cases for an implementation are mandatory for ARCs that are affecting consensus changes.  If the test suite is too large to reasonably be included inline, then consider adding it as one or more files in `../assets/arc-####/`.
 
 ## Reference Implementation
-[algokit-utils-py](https://github.com/algorandfoundation/algokit-utils-py/blob/main/src/algokit_utils/application_specification.py) and [algokit-utils-ts](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/types/app-spec.ts) both provide reference implementations for the specification structure and using the data in an `ApplicationClient` ([Python](https://github.com/algorandfoundation/algokit-utils-py/blob/main/src/algokit_utils/application_client.py) | [TypeScript](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/src/app-client.ts))
 
-[Beaker](https://github.com/algorand-devrel/beaker/blob/master/beaker/application.py#L1098C9-L1098C14) provides a reference implementation for creating an application.json from a smart contract.
+`algokit-utils-py` and `algokit-utils-ts` both provide reference implementations for the specification structure and using the data in an `ApplicationClient`
+`Beaker` provides a reference implementation for creating an application.json from a smart contract.
 
 ## Security Considerations
 All ARCs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. ARC submissions missing the "Security Considerations" section will be rejected. An ARC cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.

--- a/ARCs/arc-0032.md
+++ b/ARCs/arc-0032.md
@@ -102,13 +102,13 @@ type ABIType = string;
 type DeclaredSchemaValueSpec = {
   type: AVMType | ABIType;
   key: string;
-  desc: string;
+  descr: string;
 }
 
 // Fields that have an undetermined key
 type ReservedSchemaValueSpec = {
   type: AVMType | ABIType;
-  desc: string;
+  descr: string;
   max_keys: number;
 }
 

--- a/ARCs/arc-0032.md
+++ b/ARCs/arc-0032.md
@@ -210,10 +210,21 @@ the equivalent ABI type is `(address,uint64)` and an element in the TypeSpec is:
 
 #### Default Argument
 
-Defines how default argument values can be obtained.
+Defines how default argument values can be obtained. The `source` field defines how a default value is obtained, the `data` field
+contains additional information based on the `source` value.
 
-TODO: describe when/how this can be used
-TODO: this should probably be proposed in a separate ARC like the `read-only` attr?
+Valid values for `source` are:
+* "constant" - `data` is the value to use
+* "global-state" - `data` is the global state key.
+* "local-state" - `data` is the local state key
+* "abi-method" - `data` is a reference to the ABI method to call. Method should be read only and return a value of the appropriate type
+
+Two scenarios where providing default arguments can be useful:
+
+1. Providing a default value for optional arguments
+
+2. Providing a value for required arguments such as foreign asset or application references without requiring the client to explicitly determine these values when calling the contract
+
 
 ```ts
 // ARC-0004 ABI method definition
@@ -221,10 +232,6 @@ type ABIMethod = {};
 
 type DefaultArgumentSpec = {
   // Where to look for the default arg value 
-  // constant: a constant value as specified in data
-  // global-state: from global state using the key specified in data
-  // local-state: from local state using the key specified in data  
-  // abi-method: via the specified ABIMethod in data
   source: "constant" | "global-state" | "local-state" | "abi-method"
   // extra data to include when looking up the value
   data: string | bigint | number | ABIMethod

--- a/ARCs/arc-0032.md
+++ b/ARCs/arc-0032.md
@@ -157,7 +157,10 @@ type HintsSpec = Record<string, HintSpec>
 
 #### Readonly Specification
 
-TODO:
+Indicates the method has no side-effects and can be called via dry-run/simulate
+
+NOTE: This property is made obsolete by [ARC-0022](https://arc.algorand.foundation/ARCs/arc-0022) but is included as it is currently
+used by existing reference implementations such as Beaker
 
 #### Struct Specification
 

--- a/assets/arc-0032/application.schema.json
+++ b/assets/arc-0032/application.schema.json
@@ -1,0 +1,307 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "AlgoAppSpec",
+  "type": "object",
+  "required": ["contract", "schema", "source", "state"],
+  "additionalProperties": false,
+  "properties": {
+    "hints": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/Hint"
+      }
+    },
+    "source": {
+      "$ref": "#/definitions/AppSources"
+    },
+    "contract": {
+      "$ref": "contract.schema.json"
+    },
+    "schema": {
+      "$ref": "#/definitions/SchemaSpec"
+    },
+    "state": {
+      "$ref": "#/definitions/StateSchemaSpec"
+    },
+    "bare_call_config": {
+      "$ref": "#/definitions/CallConfig"
+    }
+  },
+  "definitions": {
+    "AVMType": {
+      "description": "AVM data type",
+      "enum": ["uint64", "bytes"]
+    },
+    "DeclaredSchemaValueSpec": {
+      "type": "object",
+      "required": ["type", "key"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "The type of the value",
+          "$ref": "#/definitions/AVMType"
+        },
+        "key": {
+          "description": "The name of the key",
+          "type": "string"
+        },
+        "descr": {
+          "description": "A description of the variable",
+          "type": "string"
+        },
+        "static": {
+          "description": "Whether the value is set statically (at create time only) or dynamically",
+          "type": "boolean"
+        }
+      }
+    },
+    "ReservedSchemaValueSpec": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "description": "The type of the value",
+          "$ref": "#/definitions/AVMType"
+        },
+        "descr": {
+          "description": "A description of the variable",
+          "type": "string"
+        },
+        "max_keys": {
+          "description": "The maximum number of slots to reserve",
+          "type": "integer"
+        }
+      }
+    },
+    "StateSchemaSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["global", "local"],
+      "properties": {
+        "global": {
+          "$ref": "#/definitions/StateSchema"
+        },
+        "local": {
+          "$ref": "#/definitions/StateSchema"
+        }
+      }
+    },
+    "StateSchema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["num_byte_slices", "num_uints"],
+      "properties": {
+        "num_uints": {
+          "type": "integer"
+        },
+        "num_byte_slices": {
+          "type": "integer"
+        }
+      }
+    },
+    "SchemaSpec": {
+      "description": "The schema for global and local storage",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "global": {
+          "$ref": "#/definitions/Schema"
+        },
+        "local": {
+          "$ref": "#/definitions/Schema"
+        }
+      }
+    },
+    "Schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "declared": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/DeclaredSchemaValueSpec"
+          }
+        },
+        "reserved": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ReservedSchemaValueSpec"
+          }
+        }
+      }
+    },
+    "AppSources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "approval": {
+          "type": "string"
+        },
+        "clear": {
+          "type": "string"
+        }
+      }
+    },
+    "Hint": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "read_only": {
+          "type": "boolean"
+        },
+        "structs": {
+          "type": "object",
+          "properties": {
+            "output": {
+              "$ref": "#/definitions/Struct"
+            }
+          },
+          "additionalProperties": {
+            "$ref": "#/definitions/Struct"
+          }
+        },
+        "default_arguments": {
+          "additionalProperties": {
+            "$ref": "#/definitions/DefaultArgument"
+          }
+        },
+        "call_config": {
+          "$ref": "#/definitions/CallConfig"
+        }
+      }
+    },
+    "CallConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "no_op": {
+          "$ref": "#/definitions/CallConfigValue"
+        },
+        "opt_in": {
+          "$ref": "#/definitions/CallConfigValue"
+        },
+        "close_out": {
+          "$ref": "#/definitions/CallConfigValue"
+        },
+        "update_application": {
+          "$ref": "#/definitions/CallConfigValue"
+        },
+        "delete_application": {
+          "$ref": "#/definitions/CallConfigValue"
+        }
+      }
+    },
+    "CallConfigValue": {
+      "enum": ["NEVER", "CALL", "CREATE", "ALL"]
+    },
+    "Struct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "elements"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "elements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StructElement"
+          }
+        }
+      }
+    },
+    "FieldName": {
+      "type": "string"
+    },
+    "ABIType": {
+      "type": "string"
+    },
+    "StructElement": {
+      "type": "array",
+      "minItems": 2,
+      "items": [
+        {
+          "$ref": "#/definitions/FieldName"
+        },
+        {
+          "$ref": "#/definitions/ABIType"
+        }
+      ]
+    },
+    "DefaultArgument": {
+      "description": "Defines a strategy for obtaining a default value for a given ABI arg.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["source", "data"],
+          "additionalProperties": false,
+          "properties": {
+            "source": {
+              "description": "The default value should be fetched by invoking an ABI method",
+              "enum": ["abi-method"]
+            },
+            "data": {
+              "description": "The contract of the ABI method to invoke.",
+              "$ref": "contract.schema.json#/definitions/ContractMethod"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["source", "data"],
+          "additionalProperties": false,
+          "properties": {
+            "source": {
+              "description": "The default value should be fetched from global state",
+              "enum": ["global-state"]
+            },
+            "data": {
+              "description": "The key of the state variable",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["source", "data"],
+          "additionalProperties": false,
+          "properties": {
+            "source": {
+              "description": "The default value should be fetched from the local state of the sender user",
+              "enum": ["local-state"]
+            },
+            "data": {
+              "description": "The key of the state variable",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["source", "data"],
+          "additionalProperties": false,
+          "properties": {
+            "source": {
+              "description": "The default value is a constant.",
+              "enum": ["constant"]
+            },
+            "data": {
+              "description": "The static default value to use.",
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/assets/arc-0032/contract.schema.json
+++ b/assets/arc-0032/contract.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "AbiContract",
+  "type": "object",
+  "required": ["name", "methods"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "desc": {
+      "type": "string"
+    },
+    "methods": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ContractMethod"
+      }
+    },
+    "networks": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["appID"],
+        "additionalProperties": false,
+        "properties": {
+          "appID": {
+            "type": "number"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ContractMethod": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "args", "returns"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContractMethodArg"
+          }
+        },
+        "desc": {
+          "type": "string"
+        },
+        "returns": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type"],
+          "properties": {
+            "desc": {
+              "type": "string"
+            },
+            "type": {
+              "$ref": "#/definitions/ABIType"
+            }
+          }
+        }
+      }
+    },
+    "ContractMethodArg": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "type"],
+      "properties": {
+        "desc": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/ABIType"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "ABIType": {
+      "description": "Catch all for fixed length arrays and tuples",
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
This PR Updates ARC-0032 to describe the current as-is usage of ARC-32 being used in Beaker and various algokit-utils libraries. The current specification is not perfect, but felt it is important to have the ARC updated to reflect it more accurately as a starting point