### PR TITLE
Update arc-0200.md

### DIFF
--- a/ARCs/arc-0200.md
+++ b/ARCs/arc-0200.md
@@ -199,7 +199,7 @@ The `arc200_Approval` event MUST be emitted when an `arc200_approve` or `arc200_
 
 The methods `arc200_transfer` `arc200_transferFrom`, and `arc200_approve` SHOULD return byte `1` on success and byte `0` on failure.
 
-The method `arc200_decimals` SHOULD return a value less than or greater than uint64 `256`
+The method `arc200_decimals` SHOULD return a value less than or equal to uint64 `256`
 
 A value of zero for the `arc200_approve` method and the `arc200_Approval` event indicates no approval.
 The `arc200_transferFrom` method and the `arc200_Approval` event indicates the approval value after it is decremented.

--- a/ARCs/arc-0200.md
+++ b/ARCs/arc-0200.md
@@ -94,7 +94,7 @@ A smart contract token that is compliant with this standard MUST implement the f
           "desc": "Amount of tokens to transfer"
         }
       ],
-      "returns": { "type": "void" }
+      "returns": { "type": "byte", "description": "Success" }
     },
     {
       "name": "arc200_transferFrom",
@@ -117,7 +117,7 @@ A smart contract token that is compliant with this standard MUST implement the f
           "desc": "Amount of tokens to transfer"
         }
       ],
-      "returns": { "type": "void" }
+      "returns": { "type": "byte", "description": "Success" }
     },
     {
       "name": "arc200_approve",
@@ -127,7 +127,7 @@ A smart contract token that is compliant with this standard MUST implement the f
         { "type": "address", "name": "spender" },
         { "type": "uint256", "name": "value" }
       ],
-      "returns": { "type": "void" }
+      "returns": { "type": "byte", "description": "Success" }
     },
     {
       "name": "arc200_allowance",
@@ -189,13 +189,16 @@ A smart contract token that is compliant with this standard MUST implement the f
 
 Ownership of a token by a zero address indicates that a token is out of circulation indefinitely, or otherwise burned or destroyed.
 
-The methods `arc200_transfer` and `arc200_transferFrom` method MUST error when the balance of `from` is insufficient. In the case of the `arc200_transfer` method, from is implied as the `owner` of the token.
-The `arc200_transferFrom` method MUST error unless called by an `spender` approved by an `owner`.
+The methods `arc200_transfer` and `arc200_transferFrom` method MAY error when the balance of `from` is insufficient. In the case of the `arc200_transfer` method, from is implied as the `owner` of the token. 
+The `arc200_transferFrom` method MAY error unless called by an `spender` approved by an `owner`.
 The methods `arc200_transfer` and `arc200_transferFrom` MUST emit a `Transfer` event.
 A `arc200_Transfer` event SHOULD be emitted, with `from` being the zero address, when a token is minted.
 A `arc200_Transfer` event SHOULD be emitted, with `to` being the zero address, when a token is destroyed.
 
 The `arc200_Approval` event MUST be emitted when an `arc200_approve` or `arc200_transferFrom` method is called successfully.
+
+The methods `arc200_transfer` `arc200_transferFrom`, and `arc200_approve` SHOULD return byte `1` on success and byte `0` on failure.
+
 
 A value of zero for the `arc200_approve` method and the `arc200_Approval` event indicates no approval.
 The `arc200_transferFrom` method and the `arc200_Approval` event indicates the approval value after it is decremented.

--- a/ARCs/arc-0200.md
+++ b/ARCs/arc-0200.md
@@ -189,8 +189,8 @@ A smart contract token that is compliant with this standard MUST implement the f
 
 Ownership of a token by a zero address indicates that a token is out of circulation indefinitely, or otherwise burned or destroyed.
 
-The methods `arc200_transfer` and `arc200_transferFrom` method MAY error when the balance of `from` is insufficient. In the case of the `arc200_transfer` method, from is implied as the `owner` of the token. 
-The `arc200_transferFrom` method MAY error unless called by an `spender` approved by an `owner`.
+The methods `arc200_transfer` and `arc200_transferFrom` method MUST error when the balance of `from` is insufficient. In the case of the `arc200_transfer` method, from is implied as the `owner` of the token. 
+The `arc200_transferFrom` method MUST error unless called by an `spender` approved by an `owner`.
 The methods `arc200_transfer` and `arc200_transferFrom` MUST emit a `Transfer` event.
 A `arc200_Transfer` event SHOULD be emitted, with `from` being the zero address, when a token is minted.
 A `arc200_Transfer` event SHOULD be emitted, with `to` being the zero address, when a token is destroyed.

--- a/ARCs/arc-0200.md
+++ b/ARCs/arc-0200.md
@@ -199,6 +199,7 @@ The `arc200_Approval` event MUST be emitted when an `arc200_approve` or `arc200_
 
 The methods `arc200_transfer` `arc200_transferFrom`, and `arc200_approve` SHOULD return byte `1` on success and byte `0` on failure.
 
+The method `arc200_decimals` SHOULD return a value less than or greater than uint64 `256`
 
 A value of zero for the `arc200_approve` method and the `arc200_Approval` event indicates no approval.
 The `arc200_transferFrom` method and the `arc200_Approval` event indicates the approval value after it is decremented.

--- a/ARCs/arc-0200.md
+++ b/ARCs/arc-0200.md
@@ -53,7 +53,7 @@ A smart contract token that is compliant with this standard MUST implement the f
       "desc": "Returns the decimals of the token",
       "readonly": true,
       "args": [],
-      "returns": { "type": "uint64", "desc": "The decimals of the token" }
+      "returns": { "type": "uint8", "desc": "The decimals of the token" }
     },
     {
       "name": "arc200_totalSupply",
@@ -94,7 +94,7 @@ A smart contract token that is compliant with this standard MUST implement the f
           "desc": "Amount of tokens to transfer"
         }
       ],
-      "returns": { "type": "byte", "description": "Success" }
+      "returns": { "type": "bool", "description": "Success" }
     },
     {
       "name": "arc200_transferFrom",
@@ -117,7 +117,7 @@ A smart contract token that is compliant with this standard MUST implement the f
           "desc": "Amount of tokens to transfer"
         }
       ],
-      "returns": { "type": "byte", "description": "Success" }
+      "returns": { "type": "bool", "description": "Success" }
     },
     {
       "name": "arc200_approve",
@@ -127,7 +127,7 @@ A smart contract token that is compliant with this standard MUST implement the f
         { "type": "address", "name": "spender" },
         { "type": "uint256", "name": "value" }
       ],
-      "returns": { "type": "byte", "description": "Success" }
+      "returns": { "type": "bool", "description": "Success" }
     },
     {
       "name": "arc200_allowance",
@@ -196,10 +196,6 @@ A `arc200_Transfer` event SHOULD be emitted, with `from` being the zero address,
 A `arc200_Transfer` event SHOULD be emitted, with `to` being the zero address, when a token is destroyed.
 
 The `arc200_Approval` event MUST be emitted when an `arc200_approve` or `arc200_transferFrom` method is called successfully.
-
-The methods `arc200_transfer` `arc200_transferFrom`, and `arc200_approve` SHOULD return byte `1` on success and byte `0` on failure.
-
-The method `arc200_decimals` SHOULD return a value less than or equal to uint64 `256`
 
 A value of zero for the `arc200_approve` method and the `arc200_Approval` event indicates no approval.
 The `arc200_transferFrom` method and the `arc200_Approval` event indicates the approval value after it is decremented.

--- a/ARCs/arc-0200.md
+++ b/ARCs/arc-0200.md
@@ -94,7 +94,7 @@ A smart contract token that is compliant with this standard MUST implement the f
           "desc": "Amount of tokens to transfer"
         }
       ],
-      "returns": { "type": "bool", "description": "Success" }
+      "returns": { "type": "bool", "desc": "Success" }
     },
     {
       "name": "arc200_transferFrom",
@@ -117,7 +117,7 @@ A smart contract token that is compliant with this standard MUST implement the f
           "desc": "Amount of tokens to transfer"
         }
       ],
-      "returns": { "type": "bool", "description": "Success" }
+      "returns": { "type": "bool", "desc": "Success" }
     },
     {
       "name": "arc200_approve",
@@ -127,7 +127,7 @@ A smart contract token that is compliant with this standard MUST implement the f
         { "type": "address", "name": "spender" },
         { "type": "uint256", "name": "value" }
       ],
-      "returns": { "type": "bool", "description": "Success" }
+      "returns": { "type": "bool", "desc": "Success" }
     },
     {
       "name": "arc200_allowance",

--- a/ARCs/arc-0200.md
+++ b/ARCs/arc-0200.md
@@ -94,7 +94,7 @@ A smart contract token that is compliant with this standard MUST implement the f
           "desc": "Amount of tokens to transfer"
         }
       ],
-      "returns": { "type": "bool", "desc": "Success" }
+      "returns": { "type": "void" }
     },
     {
       "name": "arc200_transferFrom",
@@ -117,7 +117,7 @@ A smart contract token that is compliant with this standard MUST implement the f
           "desc": "Amount of tokens to transfer"
         }
       ],
-      "returns": { "type": "bool", "desc": "Success" }
+      "returns": { "type": "void" }
     },
     {
       "name": "arc200_approve",
@@ -127,7 +127,7 @@ A smart contract token that is compliant with this standard MUST implement the f
         { "type": "address", "name": "spender" },
         { "type": "uint256", "name": "value" }
       ],
-      "returns": { "type": "bool", "desc": "Success" }
+      "returns": { "type": "void" }
     },
     {
       "name": "arc200_allowance",

--- a/ARCs/arc-0200.md
+++ b/ARCs/arc-0200.md
@@ -39,21 +39,21 @@ A smart contract token that is compliant with this standard MUST implement the f
       "desc": "Returns the name of the token",
       "readonly": true,
       "args": [],
-      "returns": { "type": "bytes[32]", "desc": "The name of the token" }
+      "returns": { "type": "byte[32]", "desc": "The name of the token" }
     },
     {
       "name": "arc200_symbol",
       "desc": "Returns the symbol of the token",
       "readonly": true,
       "args": [],
-      "returns": { "type": "bytes[8]", "desc": "The symbol of the token" }
+      "returns": { "type": "byte[8]", "desc": "The symbol of the token" }
     },
     {
       "name": "arc200_decimals",
       "desc": "Returns the decimals of the token",
       "readonly": true,
       "args": [],
-      "returns": { "type": "uint8", "desc": "The decimals of the token" }
+      "returns": { "type": "uint64", "desc": "The decimals of the token" }
     },
     {
       "name": "arc200_totalSupply",


### PR DESCRIPTION
Lines 42, 45:
Fixed typo: bytes -> byte 

Line 56: 
Propose changing arc200_decimals return type to uint64 for improved compatibility with compiled smart contracts that do not have uint8 available

Change return type of transfer, transferFrom, approve from bool to byte

Describe what non-readonly methods return values should be.

Describe decimals return value