### PR TITLE
NFT update reward cap 50-> 35%

### DIFF
--- a/ARCs/arc-0049.md
+++ b/ARCs/arc-0049.md
@@ -42,7 +42,7 @@ NFT marketplaces applying for this program:
 - The qualifying NFT marketplace must provide a detailed 1-page report following the initiative to Algorand Foundation & NFT Council that includes:
 1. Summary of the initiatives implemented;
 1. Amount of rewards paid out (including any unspent rewards, which must be returned), and wallet addresses;
-1. otal volume of transactions directly as a result of the campaign;
+1. Total volume of transactions directly as a result of the campaign;
 1. New wallets interacting with the marketplace;
 1. Total volume of transactions compared to the previous quarter;
 1. Any other relevant information.

--- a/ARCs/arc-0049.md
+++ b/ARCs/arc-0049.md
@@ -25,7 +25,7 @@ NFT marketplaces applying for this program:
 
 ### Allocation of rewards
 - Rewards will be allocated proportionally based on volume for each qualified NFT marketplace.
-- For qualifying marketplaces with more than 50% of total NFT marketplace volume, rewards will be capped at 50%.
+- For qualifying marketplaces with more than 50% of total NFT marketplace volume, rewards will be capped at 35%.
 
 ### Requirements for initiatives
 1. The rewards (ALGO) must ultimately go to NFT collectors/end users and creators.
@@ -42,7 +42,7 @@ NFT marketplaces applying for this program:
 - The qualifying NFT marketplace must provide a detailed 1-page report following the initiative to Algorand Foundation & NFT Council that includes:
 1. Summary of the initiatives implemented;
 1. Amount of rewards paid out (including any unspent rewards, which must be returned), and wallet addresses;
-1. Total volume of transactions directly as a result of the campaign;
+1. otal volume of transactions directly as a result of the campaign;
 1. New wallets interacting with the marketplace;
 1. Total volume of transactions compared to the previous quarter;
 1. Any other relevant information.


### PR DESCRIPTION
For qualifying marketplaces with more than 50% of total NFT marketplace volume, rewards will be capped at 35%.