### PR TITLE
ARC-57: Application Action Routing

### DIFF
--- a/ARCs/arc-0057.md
+++ b/ARCs/arc-0057.md
@@ -26,7 +26,7 @@ The TEAL for an application **MUST** start with the following lines:
 ```
 txn ApplicationID
 !
-pushint 6
+pushints 6
 *
 txn OnCompletion
 +

--- a/ARCs/arc-0057.md
+++ b/ARCs/arc-0057.md
@@ -1,9 +1,9 @@
 ---
-arc: <to be assigned>
+arc: 57
 title: Application Action Routing
-description: Standardized handling of OnCompletion and ApplicationID actions 
+description: Standardized handling of OnCompletion and ApplicationID actions
 author: Joe Polny (@joe-p)
-discussions-to: <URL>
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/264
 status: Draft
 type: Standards Track
 category: ARC

--- a/ARCs/arc-draft_action_routing.md
+++ b/ARCs/arc-draft_action_routing.md
@@ -1,0 +1,67 @@
+---
+arc: <to be assigned>
+title: Application Action Routing
+description: Standardized handling of OnCompletion and ApplicationID actions 
+author: Joe Polny (@joe-p)
+discussions-to: <URL>
+status: Draft
+type: Standards Track
+category: ARC
+created: 2024-01-02
+---
+
+## Abstract
+This ARC provides a standard way to handle an application call depending on the combination of the `OnCompletion` and `ApplicationID`.
+
+## Motivation
+Currently there is no way for someone to tell whether an app can be updated or deleted without doing a full static analysis on the TEAL.
+
+## Specification
+
+### TEAL
+The TEAL for an application **MUST** start with the following lines:
+
+```
+txn ApplicationID
+int 0
+>
+int 6
+*
+txn OnCompletion
++
+switch create_NoOp create_OptIn NOT_IMPLEMENTED NOT_IMPLEMENTED NOT_IMPLEMENTED create_DeleteApplication call_NoOp call_OptIn call_CloseOut NOT_IMPLEMENTED call_UpdateApplication call_DeleteApplication
+NOT_IMPLEMENTED:
+err
+```
+
+For every action (combination of `ApplicationID === 0` and `OnCompletion`) there is a label that corresponds to that action. If that action is not implemented in the contract, its label should be replaced by a label that simply contains `err`. In the above TEAL, this is the `NOT_IMPLEMENTED` label.
+
+The label containing the `err` opcode **MUST** come right after the `switch` opcode.
+
+The specific label names in the pre-compiled TEAL **MAY** be different, but it is **RECOMMENDED** to use the label names here for consistency across tooling.
+
+The `switch` statement in a contract **SHOULD** only include labels until the last supported action is reached. For example, if an application only supports `NoOp` creations, the switch can simply be `switch create_NoOp`. All other actions will simply go to the next opcode, which **MUST** be `err` as specified above.
+
+### Client Parsing
+
+A client **MUST** parse the decompiled TEAL to ensure that the firt ten opcodes match the opcodes specified in the TEAL specification. `intcblock` and `bytecblock` opcodes **MUST** be ignored if they are the first or second opcodes executed.
+
+The client **MUST** follow the label for a specific action. If that label does not exist in the `switch` opcode OR if it leads to the `err` label, then that action is known to not be supported by the TEAL.
+
+## Rationale
+Standardizing the initial opcodes of the TEAL program makes it easy for anyone to parse the TEAL, follow a label for a specific action, and and determine whether that action is supported or not. 
+
+## Backwards Compatibility
+N/A
+
+## Test Cases
+N/A
+
+## Reference Implementation
+TODO: Client parsing example
+
+## Security Considerations
+All ARCs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. ARC submissions missing the "Security Considerations" section will be rejected. An ARC cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.
+
+## Copyright
+Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.

--- a/ARCs/arc-draft_action_routing.md
+++ b/ARCs/arc-draft_action_routing.md
@@ -14,7 +14,9 @@ created: 2024-01-02
 This ARC provides a standard way to handle an application call depending on the combination of the `OnCompletion` and `ApplicationID`.
 
 ## Motivation
-Currently there is no way for someone to tell whether an app can be updated or deleted without doing a full static analysis on the TEAL.
+App mutability is an important factor in a rational actors decision making when it comes to interacting with an app and sending funds to a contract account. If a contract is mutable, it is possible that funds could be stolen or lost after the initial program is changed or deleted. Currently, there is no easy way for an end-user to determine the mutability of a contract. It is possible to use static analysis on the decompiled TEAL, but this is not easily accessible and unrealistic for wallets and explorers to implement for every program.
+
+Additionally, there is no standard way for developers to route calls based on their OnCompletion. This can make it hard to determine what is allowed for a specific code path since a check for OnCompletion can be anywhere in the program. The current common practice is to include OnCompletion checks within the methods label/subroutine, but this can lead to a lot of extra bytes in the program.  
 
 ## Specification
 
@@ -24,7 +26,7 @@ The TEAL for an application **MUST** start with the following lines:
 ```
 txn ApplicationID
 !
-int 6
+pushint 6
 *
 txn OnCompletion
 +
@@ -43,12 +45,16 @@ The `switch` statement in a contract **SHOULD** only include labels until the la
 
 ### Client Parsing
 
-A client **MUST** parse the decompiled TEAL to ensure that the firt nine lines match the lines specified in the TEAL specification. `intcblock` and `bytecblock` opcodes **MUST** be ignored if they are the first or second opcodes executed.
+A client **MUST** parse the decompiled TEAL to ensure that the firt nine lines match the lines specified in the TEAL specification. Prior to parsing, `inctblock` or `bytecblock` opcodes **MUST** be removed from the TEAL because they may come before the opcode in this ARC, but don't affect functionality.
+
+To support future changes where comments may get added to the decompiled TEAL, clients **MUST** only check the beginning of lines to ensure the opcode and its argument(s) match the specification.
 
 The client **MUST** follow the label for a specific action. If that label does not exist in the `switch` opcode OR if it leads to the `err` label, then that action is known to not be supported by the TEAL.
 
 ## Rationale
-Standardizing the initial opcodes of the TEAL program makes it easy for anyone to parse the TEAL, follow a label for a specific action, and and determine whether that action is supported or not. 
+Standardizing the initial opcodes of the TEAL program makes it easy for anyone to parse the TEAL, follow a label for a specific action, and and determine whether that action is supported or not. This makes it possible for tools in the ecosystem, such as explorers and wallets, to tell end-users whether apps they are interacting with are mutable or not.
+
+An alternative approach is to include asserts at the beginning of the program for any OnCompletion that is not supported by the contract, but this leads to a larger program size and potentially opcode cost. This approach also still makes it hard to determine what OnCompletions *are* supported for individual methods.
 
 ## Backwards Compatibility
 N/A

--- a/ARCs/arc-draft_action_routing.md
+++ b/ARCs/arc-draft_action_routing.md
@@ -23,13 +23,12 @@ The TEAL for an application **MUST** start with the following lines:
 
 ```
 txn ApplicationID
-int 0
->
+!
 int 6
 *
 txn OnCompletion
 +
-switch create_NoOp create_OptIn NOT_IMPLEMENTED NOT_IMPLEMENTED NOT_IMPLEMENTED create_DeleteApplication call_NoOp call_OptIn call_CloseOut NOT_IMPLEMENTED call_UpdateApplication call_DeleteApplication
+switch call_NoOp call_OptIn call_CloseOut NOT_IMPLEMENTED call_UpdateApplication call_DeleteApplication create_NoOp create_OptIn NOT_IMPLEMENTED NOT_IMPLEMENTED NOT_IMPLEMENTED create_DeleteApplication
 NOT_IMPLEMENTED:
 err
 ```
@@ -44,7 +43,7 @@ The `switch` statement in a contract **SHOULD** only include labels until the la
 
 ### Client Parsing
 
-A client **MUST** parse the decompiled TEAL to ensure that the firt ten opcodes match the opcodes specified in the TEAL specification. `intcblock` and `bytecblock` opcodes **MUST** be ignored if they are the first or second opcodes executed.
+A client **MUST** parse the decompiled TEAL to ensure that the firt nine lines match the lines specified in the TEAL specification. `intcblock` and `bytecblock` opcodes **MUST** be ignored if they are the first or second opcodes executed.
 
 The client **MUST** follow the label for a specific action. If that label does not exist in the `switch` opcode OR if it leads to the `err` label, then that action is known to not be supported by the TEAL.
 

--- a/ARCs/arc-draft_action_routing.md
+++ b/ARCs/arc-draft_action_routing.md
@@ -61,7 +61,7 @@ N/A
 TODO: Client parsing example
 
 ## Security Considerations
-All ARCs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. ARC submissions missing the "Security Considerations" section will be rejected. An ARC cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.
+If a client improperly implements parsing, they may mislead users about the mutability of the contract. It is imperative that `intcblock` and `bytecblock` are handled properly and the following opcodes are exactly as specificed in this ARC.
 
 ## Copyright
 Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.

--- a/ARCs/arc-draft_action_routing.md
+++ b/ARCs/arc-draft_action_routing.md
@@ -52,7 +52,7 @@ To support future changes where comments may get added to the decompiled TEAL, c
 The client **MUST** follow the label for a specific action. If that label does not exist in the `switch` opcode OR if it leads to the `err` label, then that action is known to not be supported by the TEAL.
 
 ## Rationale
-Standardizing the initial opcodes of the TEAL program makes it easy for anyone to parse the TEAL, follow a label for a specific action, and and determine whether that action is supported or not. This makes it possible for tools in the ecosystem, such as explorers and wallets, to tell end-users whether apps they are interacting with are mutable or not.
+Standardizing the initial opcodes of the TEAL program makes it easy for anyone to parse the TEAL, follow a label for a specific action, and determine whether that action is supported or not. This makes it possible for tools in the ecosystem, such as explorers and wallets, to tell end-users whether apps they are interacting with are mutable or not.
 
 An alternative approach is to include asserts at the beginning of the program for any OnCompletion that is not supported by the contract, but this leads to a larger program size and potentially opcode cost. This approach also still makes it hard to determine what OnCompletions *are* supported for individual methods.
 


### PR DESCRIPTION
This app provides standardized TEAL that a developer can use to allow tools such as explorers or wallets easily determine if an app can be updated or deleted (among other actions)