### PR TITLE
ARC-49 Add Disclaimer 2024

### DIFF
--- a/ARCs/arc-0049.md
+++ b/ARCs/arc-0049.md
@@ -23,6 +23,11 @@ NFT marketplaces applying for this program:
 - Must be an NFT marketplace on Algorand that coordinates the selling of NFTs. An NFT marketplace is defined as an online platform that facilitates third-party non-fungible token listings and transactions in ALGO on the Algorand blockchain.
 - Must have transaction volume (over the previous 6 months leading up to the application for the program) that is equivalent to at least 10% of total rewards being distributed. For example, if the total rewards amount is 500K ALGO, then the minimum volume must be 50K ALGO.
 
+**Important Note | NFT Rewards Program for US entities:**
+
+*For 2024 | Q1 we will be allowing US-based entities that fit the Program Criteria to apply for the NFT Rewards program.
+Their allocated ALGO will be converted to USDCa post prior to the payment transfer. This change will be reviewed on a periodic basis.*
+
 ### Allocation of rewards
 - Rewards will be allocated proportionally based on volume for each qualified NFT marketplace.
 - For qualifying marketplaces with more than 50% of total NFT marketplace volume, rewards will be capped at 35%.


### PR DESCRIPTION
For 2024 | Q1 we will be allowing US-based entities that fit the Program Criteria to apply for the NFT Rewards program. Their allocated ALGO will be converted to USDCa post prior to the payment transfer. This change will be reviewed on a periodic basis.