### PR TITLE
Add ARC-54 App IDs

### DIFF
--- a/ARCs/arc-0054.md
+++ b/ARCs/arc-0054.md
@@ -197,7 +197,7 @@ class ARC54 extends Contract {
 }
 ```
 
-## Deployments
+### Deployments
 
 An application per the above reference implementation has been deployed to each of Algorand's networks at these app IDs:
 

--- a/ARCs/arc-0054.md
+++ b/ARCs/arc-0054.md
@@ -73,6 +73,9 @@ The app will accept ASAs which have clawback enabled, but any such assets can ne
 The app will, of course, only be able to opt into a new ASA if it has sufficient Algo balance to cover the increase minimum balance requirement (MBR).  Callers should fund the contract account as needed to cover the opt-in requests.  It is possible for the contract to be funded by donated Algo so that subsequent callers need not pay the MBR requirement to request new ASA opt-ins.
 
 ## Reference Implementation
+
+### TEAL Approval Program
+
 ```
 #pragma version 9
 
@@ -193,6 +196,14 @@ class ARC54 extends Contract {
   }
 }
 ```
+
+## Deployments
+
+An application per the above reference implementation has been deployed to each of Algorand's networks at these app IDs:
+
+- MainNet: 1257620981
+- TestNet: 497806551
+- BetaNet: 2019020358
 
 ## Security Considerations
 It should be noted that once an asset is sent to the contract there will be no way to recover the asset unless it has clawback enabled.


### PR DESCRIPTION
Added a deployments section to ARC-54 containing the app IDs of the contracts deployed to each network.