### PR TITLE
ARC-49 Adding Wash Trading Official statement

### DIFF
--- a/ARCs/arc-0049.md
+++ b/ARCs/arc-0049.md
@@ -21,7 +21,7 @@ To be eligible to apply to this program, projects must abide by the <a href="htt
 
 NFT marketplaces applying for this program:
 - Must be an NFT marketplace on Algorand that coordinates the selling of NFTs. An NFT marketplace is defined as an online platform that facilitates third-party non-fungible token listings and transactions in ALGO on the Algorand blockchain.
-- Must have transaction volume (over the previous 6 months leading up to the application for the program) that is equivalent to at least 10% of total rewards being distributed. For example, if the total rewards amount is 500K ALGO, then the minimum volume must be 50K ALGO.
+- Must have transaction volume (over the previous 6 months leading up to the application for the program) that is equivalent to at least 10% of total rewards being distributed. For example, if the total rewards amount is 500K ALGO, then the minimum volume must be 50K ALGO.P
 
 #### Important Note
 
@@ -36,11 +36,14 @@ Their allocated ALGO will be converted to USDCa post prior to the payment transf
 
 ### Requirements for initiatives
 1. The rewards (ALGO) must ultimately go to NFT collectors/end users and creators.
-1. NFT marketplaces must share their campaign plans publicly in advance in order to qualify for the rewards.
-1. The rewards (ALGO) should be held in a separate wallet from operating funds to track on-chain transactions of how funds are being spent.
-2. The NFT marketplace must make public data that shows its trading volume in the last quarter.
-3. The NFT Council will not approve proposals that incentivize wash trading.
-4. NFT marketplaces must reward creators whose NFTs are purchased with a 5% minimum royalty.
+2. NFT marketplaces must share their campaign plans publicly in advance in order to qualify for the rewards.
+3. The rewards (ALGO) should be held in a separate wallet from operating funds to track on-chain transactions of how funds are being spent.
+4. The NFT marketplace must make public data that shows its trading volume in the last quarter.
+5. The NFT Council will not approve proposals that incentivize wash trading.
+>By definition, the term “wash trading” means a form of market manipulation where the same user simultaneously buys and sells the same asset with the intention of giving false or misleading signals about its demand or price
+6. NFT marketplaces must reward creators whose NFTs are purchased with a 5% minimum royalty.
+
+
 
 ### Process for launching initiative
 


### PR DESCRIPTION
By definition, the term “wash trading” means a form of market manipulation where the same user simultaneously buys and sells the same asset with the intention of giving false or misleading signals about its demand or price