### PR TITLE
arc-0003 - Better definition of Fungible assets

### DIFF
--- a/ARCs/arc-0003.md
+++ b/ARCs/arc-0003.md
@@ -86,6 +86,14 @@ An ASA is said to be a *fractional non-fungible token* (*fractional NFT*) if and
 
 > In other words, the total supply of the ASA is exactly 1.
 
+or 
+
+* *Total Number of Units* (`t`) **MUST** be less then or equal to 1000000.
+* *Total Number of Units* (`t`) **MUST** be equal to number of NFT fractions.
+* *Number of Digits after the Decimal Point* (`dc`) **MUST** be equal to zero.
+
+An ASA is said to be a *fungible token* (*FT*) if any of the conditions in this section are not met and complies with the rest of this standard.
+
 ### JSON Metadata File Schema
 
 > The JSON Medata File schema follow the Ethereum Improvement Proposal <a href="https://eips.ethereum.org/EIPS/eip-1155"> ERC-1155 Metadata URI JSON Schema</a> with the following main differences:


### PR DESCRIPTION
People do not use the ARC3 for fungible assets when minting tokens because pera explorer does not process fungible assets automatically because people are minting NFTs wrong.

I suggest this change to allow minting NFTs also in different then log(10) scales. If person wants to issue 42 tickets for the event he cannot do it according to this standard at the moment.

This lead to the situation that the automated scripts considers everything minted with this standard as NFT and even though there are fungible tokens minted with this standard it does not process it right.

The suggested solution is to allow minting of specific number of ASAs, for example 42, with decimals 0, and consider this as fractional NFT. This rule will have cap to 1000000 tokens. This will fix all minted NFTs from past to be correctly classified as NFTs and will allow correctly specify ARC3 Fungible tokens mints.