### PR TITLE
ARC28 argument encoding

### DIFF
--- a/ARCs/arc-0028.md
+++ b/ARCs/arc-0028.md
@@ -33,6 +33,10 @@ To derive the 4-byte prefix from the Event Signature, perform the `sha512/256` h
 
 This is the same process that is used by the [ABI Method Selector ](./arc-0004.md#method-selector) as specified in ARC-4.
 
+### Argument Encoding
+
+The arguments to a tuple **MUST** be encoded as if they were a single [ARC-4](./arc-0004.md) tuple (opposed to concatenating the encoded values together). For example, an event signature `foo(string,string)` would contain the 4-byte prefix and a `(string,string)` encoded byteslice.
+
 ### ARC-4 Extension
 
 #### Event


### PR DESCRIPTION
Explicitly states how arguments to a method must be encoded.