### PR TITLE
ARC-0080: JSON Web Tokens (JWT) Using An Algorand Account

### DIFF
--- a/ARCs/arc-0080.md
+++ b/ARCs/arc-0080.md
@@ -84,22 +84,49 @@ An Algorand address is essentially a transformed public key of a key pair that w
 In order for EdDSA keys to be encoded as a JWK, the standard [RFC 8037][rfc-8037] introduced a new key type: "OKP" (Octet Key Pair), which outlines use of public key algorithms, namely Ed25519 ([RFC 8032][rfc-8032]), with a JOSE header.
 
 When constructing the header for a JWT for Algorand accounts, the header must conform to the following:
+
 ```json
 {
-  "alg": "EdDSA",
-  "crv": "Ed25519",
-  "kty": "OKP",
-  "typ": "JWT",
-  "x": "VEji5WHLRFmFuONhBmMnflYhHj7xVZ2OD748FF7r5hE="
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "JSON Web Token (JWT) Header",
+  "type": "object",
+  "properties": {
+    "alg": {
+      "description": "Defines the cryptographic algorithm used to create the JWS",
+      "type": "string"
+    },
+    "crv": {
+      "description": "Defines the subtype, or the name of the curve used by the cryptographic algorithm",
+      "type": "string"
+    },
+    "kty": {
+      "description": "Defines the cryptographic algorithm family the cryptographic algorithm belongs to",
+      "type": "string"
+    },
+    "typ": {
+      "description": "Defines the media type of the JWT",
+      "type": "string"
+    },
+    "x": {
+      "description": "The public key of the Algorand account and is used to verify that the JWS has been signed with the correct private key of an Algorand account",
+      "type": "string"
+    }
+  },
+  "required": [
+    "alg",
+    "crv",
+    "x"
+  ]
 }
 ```
+
 where:
 * `alg`:
-  - **REQUIRED** as per [RFC 7515 section 4.1.1.][rfc-7515-section-411] that defines the cryptographic algorithm used to create an JWS.
+  - **REQUIRED** as per [RFC 7515 section 4.1.1.][rfc-7515-section-411]
   - **MUST** be `EdDSA` to indicate an Edwards-curve Digital Signature Algorithm (EdDSA) as used by Algorand accounts.
 * `crv`:
-  - **REQUIRED** as per [RFC 8037 section 2][rfc-8037-section-2]
-  - **MUST** be `Ed25519` to indicate the name of the curve, which is Curve25519 for Algorand accounts.
+  - **REQUIRED** as per [RFC 8037 section 2][rfc-8037-section-2].
+  - **MUST** be `Ed25519` to indicate the name of the curve, which is Curve25519, for Algorand accounts.
 * `kty`:
   - **OPTIONAL** the `"alg"` parameter is sufficient to infer the JWK.
   - **MUST** be `OKP` as specified in [RFC 8037][rfc-8037] for EdDSA keys.
@@ -107,7 +134,7 @@ where:
   - **OPTIONAL** as applications usually know this is a JWT.
   - **RECOMMENDED** to be `JWT` to indicate this is a JWT.
 * `x`:
-  - **REQUIRED** as per [RFC 8037 section 2][rfc-8037-section-2] and to verify the signature has been signed with the correct private key of an Algorand account.
+  - **REQUIRED** as per [RFC 8037 section 2][rfc-8037-section-2].
   - **MUST** be the public key of an Algorand account, encoded using the base64URL ([RFC 4648][rfc-4648-section-5]) encoding.
 
 <sup>[Back to top ^][title]</sup>
@@ -124,51 +151,176 @@ A claim name can fall under one of three types:
 
 ```json
 {
-  "aud": "api.awesome.com",
-  "exp": 1707782400,
-  "iat": 1707696000,
-  "iss": "dapp.awesome.com",
-  "jti": "22080a89-a283-48e7-96c5-87f17ce7a850",
-  "nbf": 1707739200,
-  "sub": "KREOFZLBZNCFTBNY4NQQMYZHPZLCCHR66FKZ3DQPXY6BIXXL4YIS232YAU"
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "JSON Web Token (JWT) Payload",
+  "type": "object",
+  "properties": {
+    "aud": {
+      "description": "Defines the intended recipient(s) of the JWT",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "format": "uri",
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "format": "uri",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "exp": {
+      "description": "Defines the date/time the JWT expires",
+      "type": "number"
+    },
+    "iat": {
+      "description": "Defines the date/time this JWT the issued",
+      "type": "number"
+    },
+    "iss": {
+      "description": "Defines the entity that issued the JWT",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "format": "uri",
+          "type": "string"
+        }
+      ]
+    },
+    "jti": {
+      "description": "A unique identifier for the JWT that is used to prevent the same JWT being replayed",
+      "type": "string"
+    },
+    "nbf": {
+      "description": "Defines the date/time after which the JWT becomes valid",
+      "type": "number"
+    },
+    "sub": {
+      "description": "Defines the subject of the JWT",
+      "type": "string"
+    }
+  }
 }
 ```
+
 where:
 * `aud`:
-  - **OPTIONAL** as per [RFC 7519 section 4.1.3.][rfc-7519-section-413] this claim identifies the intended recipient(s) of the JWT.
+  - **OPTIONAL** as per [RFC 7519 section 4.1.3.][rfc-7519-section-413]
   - **MUST** be rejected if the recipient of the JWT cannot identify itself with the value.
   - **MAY** be an array of string or URI ([RFC 3986][rfc-3986]), if there are multiple intended recipients.
   - **MUST** be a string or URI ([RFC 3986][rfc-3986]), if the intended recipient is one.
 * `exp`:
-  - **OPTIONAL** as per [RFC 7519 section 4.1.4.][rfc-7519-section-414] this claim identifies the date/time this JWT expires.
+  - **OPTIONAL** as per [RFC 7519 section 4.1.4.][rfc-7519-section-414]
   - **MUST** be a JSON numeric value representing the number of seconds from 1970-01-01T00:00:00Z UTC until the specified UTC date/time, ignoring leap seconds.
-  - **MUST** be rejected if the expiration time has passed as compared to the current date/time.
+  - **MUST** be rejected if the current date/time is after the expiration time.
 * `iat`:
-  - **OPTIONAL** as per [RFC 7519 section 4.1.6.][rfc-7519-section-416] this claim identifies the date/time this JWT was issued.
+  - **OPTIONAL** as per [RFC 7519 section 4.1.6.][rfc-7519-section-416]
   - **MUST** be a JSON numeric value representing the number of seconds from 1970-01-01T00:00:00Z UTC until the specified UTC date/time, ignoring leap seconds.
 * `iss`:
-  - **OPTIONAL** as per [RFC 7519 section 4.1.1.][rfc-7519-section-411] this claim identifies the entity that issued the JWT. This can be a dApp or a wallet.
+  - **OPTIONAL** as per [RFC 7519 section 4.1.1.][rfc-7519-section-411]
   - **MUST** be a string or URI ([RFC 3986][rfc-3986]).
+  - **RECOMMENDED** be the dApp or wallet.
 * `jti`:
-  - **OPTIONAL** as per [RFC 7519 section 4.1.7.][rfc-7519-section-417] this claim identifies the recipient of the JWT. This claim is used to prevent the same JWT being replayed.
+  - **OPTIONAL** as per [RFC 7519 section 4.1.7.][rfc-7519-section-417]
   - **MUST** be a value that ensures a negligible probability that the same value will appear on another JWT.
   - **RECOMMENDED** be a UUIDv4 ([RFC 4122][rfc-4122]) compliant string.
 * `nbf`:
-  - **OPTIONAL** as per [RFC 7519 section 4.1.5.][rfc-7519-section-415] this claim identifies the date/time after which this JWT becomes valid.
+  - **OPTIONAL** as per [RFC 7519 section 4.1.5.][rfc-7519-section-415]
   - **MUST** be a JSON numeric value representing the number of seconds from 1970-01-01T00:00:00Z UTC until the specified UTC date/time, ignoring leap seconds.
-  - **MUST** be rejected if the not before time is after the current date/time.
+  - **MUST** be rejected if the current date/time is before the "not before" time.
 * `sub`:
-  - **OPTIONAL** as per [RFC 7519 section 4.1.2.][rfc-7519-section-412] this claim identifies the subject of the JWT.
-  - **RECOMMENDED** be the public key of the key pair used in the JWS, with a 4 byte checksum appended and encoded using base32 ([RFC 4648][rfc-4648-section-6]) encoding, as defined in ([keys and addresses][algorand-keys-and-addresses]); the Algorand address.
+  - **OPTIONAL** as per [RFC 7519 section 4.1.2.][rfc-7519-section-412]
+  - **RECOMMENDED** be the public key of the key pair used in the JWS, with a 4 byte checksum appended and encoded using base32 ([RFC 4648][rfc-4648-section-6]) encoding; the Algorand address, as defined in ([keys and addresses][algorand-keys-and-addresses]).
 
 <sup>[Back to top ^][title]</sup>
 
 ### Signature
 
+The signature is used to verify the message isn't changed along the way, and is signed with the private key of the Algorand account. 
+
+The signature is made up of the header and the payload, where each part **MUST** be encoded using base64URL ([RFC 4648][rfc-4648-section-5]) encoding, concatenated with a dot (`.`), and then the resulting string is signed using the private key of the Algorand account. Finally, the signature's bytes **MUST** be encoded using base64URL ([RFC 4648][rfc-4648-section-5]) encoding.
+
+```
+ed25529Sign(
+  base64UrlEncode(header) + "." + base64UrlEncode(payload),
+  privateKey
+)
+```
+
+For example, given a header:
+
+```json
+{
+  "alg": "EdDSA",
+  "crv": "Ed25519",
+  "kty": "OKP",
+  "typ": "JWT",
+  "x": "FrMUY1-U6zLa5xz3r0RUmILVwqyIY30HX4JWEXTN2grk9Djs"
+}
+```
+
+And a payload:
+
+```json
+{
+  "aud": "https://api.awesome.com",
+  "exp": 1707782400,
+  "iat": 1707696000,
+  "iss": "https://dapp.awesome.com",
+  "jti": "22080a89-a283-48e7-96c5-87f17ce7a850",
+  "nbf": 1707739200,
+  "sub": "C2ZRIY27STVTFWXHDT326RCUTCBNLQVMRBRX2B27QJLBC5GN3IFOJ5BY5Q"
+}
+```
+
+Encode each part using base64URL ([RFC 4648][rfc-4648-section-5]) encoding and concatenate with a dot (`.`) to produce:
+
+```
+eyJhbGciOiJFZERTQSIsImNydiI6IkVkMjU1MTkiLCJrdHkiOiJPS1AiLCJ0eXAiOiJKV1QiLCJ4IjoiRnJNVVkxLVU2ekxhNXh6M3IwUlVtSUxWd3F5SVkzMEhYNEpXRVhUTjJncms5RGpzIn0.
+eyJhdWQiOiJodHRwczovL2FwaS5hd2Vzb21lLmNvbSIsImV4cCI6MTcwNzc4MjQwMCwiaWF0IjoxNzA3Njk2MDAwLCJpc3MiOiJodHRwczovL2RhcHAuYXdlc29tZS5jb20iLCJqdGkiOiIyMjA4MGE4OS1hMjgzLTQ4ZTctOTZjNS04N2YxN2NlN2E4NTAiLCJuYmYiOjE3MDc3MzkyMDAsInN1YiI6IkMyWlJJWTI3U1RWVEZXWEhEVDMyNlJDVVRDQk5MUVZNUkJSWDJCMjdRSkxCQzVHTjNJRk9KNUJZNVEifQ
+```
+
+> ⚠️ **NOTE**: line breaks have been used in the above example.
+
+Finally, the message can be signed using the private key, encoded using base64URL ([RFC 4648][rfc-4648-section-5]) encoding, to produce the following signature:
+
+```
+wRUxp_9qLAutcXpzVaxKZpe3foQfQU2CDsIQZLXvVadhpDFN52ZYDHq3hk4C7bw65DetjRiaCCsPzj86I-QjDg==
+```
+
+<sup>[Back to top ^][title]</sup>
+
+### A JSON Web Token
+
+Once the header, payload and signature have been created, the complete token is simply a concatenation of the three parts using a dot (`.`) as a delimiter:
+
+```
+eyJhbGciOiJFZERTQSIsImNydiI6IkVkMjU1MTkiLCJrdHkiOiJPS1AiLCJ0eXAiOiJKV1QiLCJ4IjoiRnJNVVkxLVU2ekxhNXh6M3IwUlVtSUxWd3F5SVkzMEhYNEpXRVhUTjJncms5RGpzIn0.
+eyJhdWQiOiJodHRwczovL2FwaS5hd2Vzb21lLmNvbSIsImV4cCI6MTcwNzc4MjQwMCwiaWF0IjoxNzA3Njk2MDAwLCJpc3MiOiJodHRwczovL2RhcHAuYXdlc29tZS5jb20iLCJqdGkiOiIyMjA4MGE4OS1hMjgzLTQ4ZTctOTZjNS04N2YxN2NlN2E4NTAiLCJuYmYiOjE3MDc3MzkyMDAsInN1YiI6IkMyWlJJWTI3U1RWVEZXWEhEVDMyNlJDVVRDQk5MUVZNUkJSWDJCMjdRSkxCQzVHTjNJRk9KNUJZNVEifQ.
+wRUxp_9qLAutcXpzVaxKZpe3foQfQU2CDsIQZLXvVadhpDFN52ZYDHq3hk4C7bw65DetjRiaCCsPzj86I-QjDg==
+```
+
+> ⚠️ **NOTE**: line breaks have been used in the above example.
+
 <sup>[Back to top ^][title]</sup>
 
 ### Verification
 
+To verify the token, you can take the signature, 
 <!-- TODO: explain how it is verified with an algorand account -->
 
 <sup>[Back to top ^][title]</sup>
@@ -187,7 +339,76 @@ where:
 
 ## Reference Implementation
 
-<!-- TODO: show examples using `jsonwebtoken`, `tweetnacl.js` and `crypto` -->
+> 🚨 **WARNING**: The below examples use third party libraries and while they serve merely as examples, you should choose your own cryptographic implementation based an implementation you trust and that has been well audited.
+
+<sup>[Back to top ^][title]</sup>
+
+### 1. A TypeScript Implementation Using TweetNaCl.js
+
+The following examples use the popular [TweetNaCl.js][tweetnacl-js] library for cryptographic signing and verification.
+
+> ⚠️ **NOTE**: At the time of writing this ARC [TweetNaCl.js][tweetnacl-js] was last audited between January-February 2017, you can read the full audit report [here](https://cure53.de/tweetnacl.pdf).
+
+For creating and signing a JWT:
+
+```typescript
+import { decodeAddress, mnemonicToSecretKey } from 'algosdk';
+import { sign } from 'tweetnacl';
+
+const { addr, sk } = mnemonicToSecretKey('host degree host...'); // get the address and private key from the 25-word mnemonic seed phrase
+const encodedPublicKey: string = Buffer.from(decodeAddress(addr).publicKey).toString('base64url');
+const header: string = JSON.stringify({
+  alg: 'EdDSA',
+  crv: 'Ed25519',
+  kty: 'OKP',
+  typ: 'JWT',
+  x: encodedPublicKey, // FrMUY1-U6zLa5xz3r0RUmILVwqyIY30HX4JWEXTN2grk9Djs
+});
+const payload: string = JSON.stringify({
+  aud: 'https://api.awesome.com',
+  exp: 1707782400,
+  iat: 1707696000,
+  iss: 'https://dapp.awesome.com',
+  jti: '22080a89-a283-48e7-96c5-87f17ce7a850',
+  nbf: 1707739200,
+  sub: addr, // C2ZRIY27STVTFWXHDT326RCUTCBNLQVMRBRX2B27QJLBC5GN3IFOJ5BY5Q
+});
+const encodedHeader: string = Buffer.from(header).toString('base64url');
+const encodedPayload: string = Buffer.from(payload).toString('base64url');
+const signature: Uint8Array = sign.detached(
+  new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`),
+  sk, // sign with the algorand account's private key
+);
+const encodedSignature: string = Buffer.from(signature).toString('base64url');
+
+console.log(`json web token: ${encodedHeader}.${encodedPayload}.${encodedSignature}`);
+/*
+json web token: eyJhbGciOiJFZERTQSIsImNydiI6IkVkMjU1MTkiLCJrdHkiOiJPS1AiLCJ0eXAiOiJKV1QiLCJ4IjoiRnJNVVkxLVU2ekxhNXh6M3IwUlVtSUxWd3F5SVkzMEhYNEpXRVhUTjJncms5RGpzIn0.eyJhdWQiOiJodHRwczovL2FwaS5hd2Vzb21lLmNvbSIsImV4cCI6MTcwNzc4MjQwMCwiaWF0IjoxNzA3Njk2MDAwLCJpc3MiOiJodHRwczovL2RhcHAuYXdlc29tZS5jb20iLCJqdGkiOiIyMjA4MGE4OS1hMjgzLTQ4ZTctOTZjNS04N2YxN2NlN2E4NTAiLCJuYmYiOjE3MDc3MzkyMDAsInN1YiI6IkMyWlJJWTI3U1RWVEZXWEhEVDMyNlJDVVRDQk5MUVZNUkJSWDJCMjdRSkxCQzVHTjNJRk9KNUJZNVEifQ.wRUxp_9qLAutcXpzVaxKZpe3foQfQU2CDsIQZLXvVadhpDFN52ZYDHq3hk4C7bw65DetjRiaCCsPzj86I-QjDg==
+ */
+```
+
+To verify the JWT: 
+
+```typescript
+import { decodeAddress, mnemonicToSecretKey } from 'algosdk';
+import { sign } from 'tweetnacl';
+
+const [encodedHeader, encodedPayload, encodedSignature] = jwt.split('.');
+const decodedHeader: Uint8Array = Buffer.from(encodedHeader, 'base64url');
+const decodedSignature: Uint8Array = Buffer.from(encodedSignature, 'base64url');
+const { x } = JSON.parse(decodedHeader.toString()); // get the "x" parameter; the public key, from the header
+const decodedPublicKey: Uint8Array = Buffer.from(x, 'base64url');
+const isVerified: boolean = sign.detached.verify(
+  new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`), // re-create the signed message
+  decodedSignature,
+  decodedPublicKey,
+);
+
+console.log('is verified: ', isVerified);
+/*
+is verified: true
+ */
+```
 
 <sup>[Back to top ^][title]</sup>
 
@@ -222,3 +443,4 @@ Copyright and related rights waived via <a href="https://creativecommons.org/pub
 [rfc-8037]: https://datatracker.ietf.org/doc/html/rfc8037
 [rfc-8037-section-2]: https://datatracker.ietf.org/doc/html/rfc8037#section-2
 [title]: #authentication-with-json-web-token-jwt
+[tweetnacl-js]: https://github.com/dchest/tweetnacl-js

--- a/ARCs/arc-0080.md
+++ b/ARCs/arc-0080.md
@@ -1,0 +1,127 @@
+---
+arc: 80
+title: Authentication with JSON Web Token (JWT)
+description: A specification that outlines authentication with JSON Web Tokens (JWT).
+author: Kieran O'Neill (@kieranroneill)
+status: Draft
+type: Standards Track
+category: Interface
+created: 2024-02-12
+---
+
+# Authentication with JSON Web Token (JWT)
+
+## Abstract
+
+JSON Web Tokens (JWTs) were proposed in the specification [RFC 7519][rfc-7519] and are a popular format that represent a claim that can be transferred between two parties. 
+
+This proposal aims to build upon the JWT standard, but with a focus on using JWTs within the context of an Algorand account; a public/private key pair using Ed25519 elliptic-curve signatures.
+
+## Motivation
+
+Authentication is a wide-ranging subject, and it's implementation can be done in many different ways. This proposal does not aim to enforce a defacto authentication method for Algorand, but merely outlines a popular authentication method: JSON Web Token (JWT), within the context of an Algorand account.
+
+The intention of this proposal is to live alongside other authentication methods.
+
+## Specification
+
+The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC-2119</a>.
+
+> Comments like this are non-normative.
+
+### Definitions
+
+This section is non-normative.
+
+* Claim
+  - A piece of information asserted about a subject, represented as a name/value pair.
+* JSON Web Algorithms (JWA)
+  - A registered list of cryptographic algorithms by the [IANA][iana-jwa-list]; it represents the allowed values of the `"alg"` parameter of a JSON Web Token (JWT)'s header.
+* JSON Web Key (JWK)
+  - A JSON object that represents the structure of the cryptographic mechanism using the JSON Web Signature (JWS).
+* JSON Web Signature (JWS)
+  - Represents a content signature signed with a cryptographic mechanism.
+* JSON Web Token (JWT)
+  - A JSON object, with a set of claims, encoded in a JSON Web Signature (JWS).
+
+### Overview
+
+JSON Web Token (JWT) is an open standard ([RFC 7519][rfc-7519]) that allows a compact, URL-safe means of representing claims that can be transferred between two parties.
+
+A JWT consists of three parts separated by dots (`.`): 
+
+* Header - contains information about the type of token and the signing algorithm used.
+* Payload - contains the claims, which are statements about an entity (typically, the user) and additional data.
+* Signature - is used to verify that the sender of the JWT is who it says it is and to ensure that the message wasn't changed along the way.
+
+Therefore, a JWT will look like the following:
+```
+header.payload.signature
+```
+
+> ⚠️ **NOTE**: Each part of the JWT **MUST** be encoded using base64URL ([RFC 4648][rfc-4648-section-5]) encoding.
+
+### Header
+
+An Algorand address is essentially a transformed public key of a key pair that was created using an EdDSA signature with the Curve25519; or Ed25519 for short.
+
+In order for EdDSA keys to be encoded as a JWK, the standard [RFC 8037][rfc-8037] introduced a new key type: "OKP" (Octet Key Pair), that outlines use of public key algorithms, namely Ed25519 ([RFC 8032][rfc-8032]), with a JOSE header.
+
+When constructing the header for a JWT for Algorand accounts, the header must conform to the following:
+```json
+{
+  "alg": "EdDSA",
+  "crv": "Ed25519",
+  "kty": "OKP",
+  "typ": "JWT",
+  "x": "VEji5WHLRFmFuONhBmMnflYhHj7xVZ2OD748FF7r5hE="
+}
+```
+where:
+* `alg`:
+  - **REQUIRED** as per [RFC 7515 section 4.1.1.][rfc-7515-section-411] that defines the cryptographic algorithm used to create an JWS.
+  - **MUST** be `EdDSA` to indicate an Edwards-curve Digital Signature Algorithm (EdDSA) as used by Algorand accounts.
+* `crv`:
+  - **REQUIRED** as per [RFC 8037 section 2][rfc-8037-section-2]
+  - **MUST** be `Ed25519` to indicate the name of the curve, which is Curve25519 for Algorand accounts.
+* `kty`:
+  - **OPTIONAL** the `"alg"` parameter is sufficient to infer the JWK.
+  - **MUST** be `OKP` as specified in [RFC 8037][rfc-8037] for EdDSA keys.
+* `typ`:
+  - **OPTIONAL** as applications usually know this is a JWT.
+  - **RECOMMENDED** to be `JWT` to indicate this is a JWT.
+* `x`:
+  - **REQUIRED** as per [RFC 8037 section 2][rfc-8037-section-2] and to verify the signature has been signed with the correct private key of an Algorand account.
+  - **MUST** be the public key of an Algorand account, encoded using the base64URL ([RFC 4648][rfc-4648-section-5]) encoding.
+
+### Payload
+
+
+
+### Signature
+
+
+
+## Rationale
+
+
+
+## Reference Implementation
+
+<!-- TODO: show exmaples using `jsonwebtoken`, `tweetnacl.js` and `crypto` -->
+
+## Security Considerations
+
+None.
+
+## Copyright
+Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.
+
+<!-- links -->
+[iana-jwa-list]: https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms
+[rfc-4648-section-5]: https://datatracker.ietf.org/doc/html/rfc4648#section-5
+[rfc-7515-section-411]: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.1
+[rfc-7519]: https://datatracker.ietf.org/doc/html/rfc7519
+[rfc-8032]: https://datatracker.ietf.org/doc/html/rfc8032
+[rfc-8037]: https://datatracker.ietf.org/doc/html/rfc8037
+[rfc-8037-section-2]: https://datatracker.ietf.org/doc/html/rfc8037#section-2

--- a/ARCs/arc-0080.md
+++ b/ARCs/arc-0080.md
@@ -1,7 +1,7 @@
 ---
 arc: 80
-title: Authentication with JSON Web Tokens (JWT)
-description: A specification that outlines authentication with JSON Web Tokens (JWT).
+title: JSON Web Tokens (JWT) Using An Algorand Account
+description: A specification that outlines using a JSON Web Tokens (JWT) within the context of an Algorand account.
 author: Kieran O'Neill (@kieranroneill)
 status: Draft
 type: Standards Track

--- a/ARCs/arc-0080.md
+++ b/ARCs/arc-0080.md
@@ -17,9 +17,11 @@ JSON Web Tokens (JWTs) were proposed in the specification [RFC 7519][rfc-7519] a
 
 This proposal aims to build upon the JWT standard, but with a focus on using JWTs within the context of an Algorand account; a public/private key pair using Ed25519 elliptic-curve signatures.
 
+The primary purpose of this proposal is to identify the subject of a JWT; the Algorand account, and verify it.
+
 ## Motivation
 
-Authentication is a wide-ranging subject, and it's implementation can be done in many different ways. This proposal does not aim to enforce a defacto authentication method for Algorand, but merely outlines a popular authentication method: JSON Web Token (JWT), within the context of an Algorand account.
+Authentication is a wide-ranging subject, and it's implementation can be done in many different ways. This proposal does not aim to enforce a defacto authentication method for Algorand, but to merely outline a possible authentication method: JSON Web Token (JWT) within the context of an Algorand account.
 
 The intention of this proposal is to live alongside other authentication methods.
 
@@ -34,7 +36,11 @@ The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL 
 This section is non-normative.
 
 * Claim
-  - A piece of information asserted about a subject, represented as a name/value pair.
+  - A piece of information asserted about a subject, represented as a key/value pair.
+* Claim Name
+  - The "key" part of the claim (key/value pair). It **MUST** be a string.
+* Claim Value
+  - The "value" part of the claim (key/value pair). It **MAY** be any JSON value.
 * JSON Web Algorithms (JWA)
   - A registered list of cryptographic algorithms by the [IANA][iana-jwa-list]; it represents the allowed values of the `"alg"` parameter of a JSON Web Token (JWT)'s header.
 * JSON Web Key (JWK)
@@ -50,9 +56,9 @@ JSON Web Token (JWT) is an open standard ([RFC 7519][rfc-7519]) that allows a co
 
 A JWT consists of three parts separated by dots (`.`): 
 
-* Header - contains information about the type of token and the signing algorithm used.
-* Payload - contains the claims, which are statements about an entity (typically, the user) and additional data.
-* Signature - is used to verify that the sender of the JWT is who it says it is and to ensure that the message wasn't changed along the way.
+* **Header** - contains information about the type of token and the signing algorithm used.
+* **Payload** - contains the claims, which are statements about an entity (typically, the user) and additional data.
+* **Signature** - is used to verify that the sender of the JWT is who it says it is and to ensure that the message wasn't changed along the way.
 
 Therefore, a JWT will look like the following:
 ```
@@ -65,7 +71,7 @@ header.payload.signature
 
 An Algorand address is essentially a transformed public key of a key pair that was created using an EdDSA signature with the Curve25519; or Ed25519 for short.
 
-In order for EdDSA keys to be encoded as a JWK, the standard [RFC 8037][rfc-8037] introduced a new key type: "OKP" (Octet Key Pair), that outlines use of public key algorithms, namely Ed25519 ([RFC 8032][rfc-8032]), with a JOSE header.
+In order for EdDSA keys to be encoded as a JWK, the standard [RFC 8037][rfc-8037] introduced a new key type: "OKP" (Octet Key Pair), which outlines use of public key algorithms, namely Ed25519 ([RFC 8032][rfc-8032]), with a JOSE header.
 
 When constructing the header for a JWT for Algorand accounts, the header must conform to the following:
 ```json
@@ -96,19 +102,72 @@ where:
 
 ### Payload
 
+The payload contains the claims of the JWT. A claim is a JSON object of key/value pairs that can provide specific details about the entity (the owner of the Algorand account) or the intention of the entity. While the structure of the claim is not enforced, each claim name **MUST** be unique and the recipient **MUST** reject the JWT if there are duplicate claim names.
 
+A claim name can fall under one of three types:
+
+* **Registered** - are claim names that have been registered in the IANA "JSON Web Token Claims" registry and while each is not mandatory they are **RECOMMENDED**.
+* **Public** - are claim names that are a public name; a value that contains a collision-resistant name.
+* **Private** - are custom claim names that are agreed by all parties and are neither _registered_ nor _public_.
+
+```json
+{
+  "aud": "api.awesome.com",
+  "exp": 1707782400,
+  "iat": 1707696000,
+  "iss": "dapp.awesome.com",
+  "jti": "22080a89-a283-48e7-96c5-87f17ce7a850",
+  "nbf": 1707739200,
+  "sub": "KREOFZLBZNCFTBNY4NQQMYZHPZLCCHR66FKZ3DQPXY6BIXXL4YIS232YAU"
+}
+```
+where:
+* `aud`:
+  - **OPTIONAL** as per [RFC 7519 section 4.1.3.][rfc-7519-section-413] this claim identifies the intended recipient(s) of the JWT.
+  - **MUST** be rejected if the recipient of the JWT cannot identify itself with the value.
+  - **MAY** be an array of string or URI ([RFC 3986][rfc-3986]), if there are multiple intended recipients.
+  - **MUST** be a string or URI ([RFC 3986][rfc-3986]), if the intended recipient is one.
+* `exp`:
+  - **OPTIONAL** as per [RFC 7519 section 4.1.4.][rfc-7519-section-414] this claim identifies the date/time this JWT expires.
+  - **MUST** be a JSON numeric value representing the number of seconds from 1970-01-01T00:00:00Z UTC until the specified UTC date/time, ignoring leap seconds.
+  - **MUST** be rejected if the expiration time has passed as compared to the current date/time.
+* `iat`:
+  - **OPTIONAL** as per [RFC 7519 section 4.1.6.][rfc-7519-section-416] this claim identifies the date/time this JWT was issued.
+  - **MUST** be a JSON numeric value representing the number of seconds from 1970-01-01T00:00:00Z UTC until the specified UTC date/time, ignoring leap seconds.
+* `iss`:
+  - **OPTIONAL** as per [RFC 7519 section 4.1.1.][rfc-7519-section-411] this claim identifies the entity that issued the JWT. This can be a dApp or a wallet.
+  - **MUST** be a string or URI ([RFC 3986][rfc-3986]).
+* `jti`:
+  - **OPTIONAL** as per [RFC 7519 section 4.1.7.][rfc-7519-section-417] this claim identifies the recipient of the JWT. This claim is used to prevent the same JWT being replayed.
+  - **MUST** be a value that ensures a negligible probability that the same value will appear on another JWT.
+  - **RECOMMENDED** be a UUIDv4 ([RFC 4122][rfc-4122]) compliant string.
+* `nbf`:
+  - **OPTIONAL** as per [RFC 7519 section 4.1.5.][rfc-7519-section-415] this claim identifies the date/time after which this JWT becomes valid.
+  - **MUST** be a JSON numeric value representing the number of seconds from 1970-01-01T00:00:00Z UTC until the specified UTC date/time, ignoring leap seconds.
+  - **MUST** be rejected if the not before time is after the current date/time.
+* `sub`:
+  - **OPTIONAL** as per [RFC 7519 section 4.1.2.][rfc-7519-section-412] this claim identifies the subject of the JWT.
+  - **RECOMMENDED** be the public key of the key pair used in the JWS, with a 4 byte checksum appended and encoded using base32 ([RFC 4648][rfc-4648-section-6]) encoding, as defined in ([keys and addresses][algorand-keys-and-addresses]); the Algorand address.
 
 ### Signature
 
 
 
+### Verification
+
+<!-- TODO: explain how it is verified with an algorand account -->
+
+### Authentication
+
+<!-- TODO: explain how it can be used in an authorization header draw a diagram -->
+
 ## Rationale
 
-
+<!-- TODO: explain that this JWT why this can be used to identify an algorand account -->
 
 ## Reference Implementation
 
-<!-- TODO: show exmaples using `jsonwebtoken`, `tweetnacl.js` and `crypto` -->
+<!-- TODO: show examples using `jsonwebtoken`, `tweetnacl.js` and `crypto` -->
 
 ## Security Considerations
 
@@ -119,9 +178,20 @@ Copyright and related rights waived via <a href="https://creativecommons.org/pub
 
 <!-- links -->
 [iana-jwa-list]: https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms
+[algorand-keys-and-addresses]: https://developer.algorand.org/docs/get-details/accounts/#keys-and-addresses
+[rfc-3986]: https://datatracker.ietf.org/doc/html/rfc3986
+[rfc-4122]: https://datatracker.ietf.org/doc/html/rfc4122
 [rfc-4648-section-5]: https://datatracker.ietf.org/doc/html/rfc4648#section-5
+[rfc-4648-section-6]: https://datatracker.ietf.org/doc/html/rfc4648#section-6
 [rfc-7515-section-411]: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.1
 [rfc-7519]: https://datatracker.ietf.org/doc/html/rfc7519
+[rfc-7519-section-411]: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1
+[rfc-7519-section-412]: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2
+[rfc-7519-section-413]: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
+[rfc-7519-section-414]: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
+[rfc-7519-section-415]: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5
+[rfc-7519-section-416]: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.6
+[rfc-7519-section-417]: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.57
 [rfc-8032]: https://datatracker.ietf.org/doc/html/rfc8032
 [rfc-8037]: https://datatracker.ietf.org/doc/html/rfc8037
 [rfc-8037-section-2]: https://datatracker.ietf.org/doc/html/rfc8037#section-2

--- a/ARCs/arc-0080.md
+++ b/ARCs/arc-0080.md
@@ -19,17 +19,23 @@ This proposal aims to build upon the JWT standard, but with a focus on using JWT
 
 The primary purpose of this proposal is to identify the subject of a JWT; the Algorand account, and verify it.
 
+<sup>[Back to top ^][title]</sup>
+
 ## Motivation
 
 Authentication is a wide-ranging subject, and it's implementation can be done in many different ways. This proposal does not aim to enforce a defacto authentication method for Algorand, but to merely outline a possible authentication method: JSON Web Token (JWT) within the context of an Algorand account.
 
 The intention of this proposal is to live alongside other authentication methods.
 
+<sup>[Back to top ^][title]</sup>
+
 ## Specification
 
 The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC-2119</a>.
 
 > Comments like this are non-normative.
+
+<sup>[Back to top ^][title]</sup>
 
 ### Definitions
 
@@ -50,6 +56,8 @@ This section is non-normative.
 * JSON Web Token (JWT)
   - A JSON object, with a set of claims, encoded in a JSON Web Signature (JWS).
 
+<sup>[Back to top ^][title]</sup>
+
 ### Overview
 
 JSON Web Token (JWT) is an open standard ([RFC 7519][rfc-7519]) that allows a compact, URL-safe means of representing claims that can be transferred between two parties.
@@ -66,6 +74,8 @@ header.payload.signature
 ```
 
 > ⚠️ **NOTE**: Each part of the JWT **MUST** be encoded using base64URL ([RFC 4648][rfc-4648-section-5]) encoding.
+
+<sup>[Back to top ^][title]</sup>
 
 ### Header
 
@@ -99,6 +109,8 @@ where:
 * `x`:
   - **REQUIRED** as per [RFC 8037 section 2][rfc-8037-section-2] and to verify the signature has been signed with the correct private key of an Algorand account.
   - **MUST** be the public key of an Algorand account, encoded using the base64URL ([RFC 4648][rfc-4648-section-5]) encoding.
+
+<sup>[Back to top ^][title]</sup>
 
 ### Payload
 
@@ -149,32 +161,46 @@ where:
   - **OPTIONAL** as per [RFC 7519 section 4.1.2.][rfc-7519-section-412] this claim identifies the subject of the JWT.
   - **RECOMMENDED** be the public key of the key pair used in the JWS, with a 4 byte checksum appended and encoded using base32 ([RFC 4648][rfc-4648-section-6]) encoding, as defined in ([keys and addresses][algorand-keys-and-addresses]); the Algorand address.
 
+<sup>[Back to top ^][title]</sup>
+
 ### Signature
 
-
+<sup>[Back to top ^][title]</sup>
 
 ### Verification
 
 <!-- TODO: explain how it is verified with an algorand account -->
 
+<sup>[Back to top ^][title]</sup>
+
 ### Authentication
 
 <!-- TODO: explain how it can be used in an authorization header draw a diagram -->
+
+<sup>[Back to top ^][title]</sup>
 
 ## Rationale
 
 <!-- TODO: explain that this JWT why this can be used to identify an algorand account -->
 
+<sup>[Back to top ^][title]</sup>
+
 ## Reference Implementation
 
 <!-- TODO: show examples using `jsonwebtoken`, `tweetnacl.js` and `crypto` -->
+
+<sup>[Back to top ^][title]</sup>
 
 ## Security Considerations
 
 None.
 
+<sup>[Back to top ^][title]</sup>
+
 ## Copyright
 Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.
+
+<sup>[Back to top ^][title]</sup>
 
 <!-- links -->
 [iana-jwa-list]: https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms
@@ -195,3 +221,4 @@ Copyright and related rights waived via <a href="https://creativecommons.org/pub
 [rfc-8032]: https://datatracker.ietf.org/doc/html/rfc8032
 [rfc-8037]: https://datatracker.ietf.org/doc/html/rfc8037
 [rfc-8037-section-2]: https://datatracker.ietf.org/doc/html/rfc8037#section-2
+[title]: #authentication-with-json-web-token-jwt

--- a/ARCs/arc-0080.md
+++ b/ARCs/arc-0080.md
@@ -1,6 +1,6 @@
 ---
 arc: 80
-title: Authentication with JSON Web Token (JWT)
+title: Authentication with JSON Web Tokens (JWT)
 description: A specification that outlines authentication with JSON Web Tokens (JWT).
 author: Kieran O'Neill (@kieranroneill)
 status: Draft
@@ -15,7 +15,7 @@ created: 2024-02-12
 
 JSON Web Tokens (JWTs) were proposed in the specification [RFC 7519][rfc-7519] and are a popular format that represent a claim that can be transferred between two parties. 
 
-This proposal aims to build upon the JWT standard, but with a focus on using JWTs within the context of an Algorand account; a public/private key pair using Ed25519 elliptic-curve signatures.
+This proposal aims to outline upon the JWT standard, but with a focus on using JWTs within the context of an Algorand account; a public/private key pair using Ed25519 elliptic-curve signatures.
 
 The primary purpose of this proposal is to identify the subject of a JWT; the Algorand account, and verify it.
 
@@ -252,7 +252,9 @@ where:
 
 The signature is used to verify the message isn't changed along the way, and is signed with the private key of the Algorand account. 
 
-The signature is made up of the header and the payload, where each part **MUST** be encoded using base64URL ([RFC 4648][rfc-4648-section-5]) encoding, concatenated with a dot (`.`), and then the resulting string is signed using the private key of the Algorand account. Finally, the signature's bytes **MUST** be encoded using base64URL ([RFC 4648][rfc-4648-section-5]) encoding.
+As defined in [RFC 7515 section 3][rfc-7515-section-3], the signature is a JSOE header, whose members are the union of the header and payload, where each part **MUST** be encoded using base64URL ([RFC 4648][rfc-4648-section-5]) encoding, concatenated with a dot (`.`), and then the resulting string is signed using the private key of the Algorand account. 
+
+Finally, the signature's bytes **MUST** be encoded using base64URL ([RFC 4648][rfc-4648-section-5]) encoding.
 
 ```
 ed25529Sign(
@@ -339,15 +341,15 @@ To verify the token, you can take the signature,
 
 ## Reference Implementation
 
-> 🚨 **WARNING**: The below examples use third party libraries and while they serve merely as examples, you should choose your own cryptographic implementation based an implementation you trust and that has been well audited.
+> 🚨 **WARNING**: The below examples may use third party libraries and while they serve merely as examples, you should choose your own cryptographic implementation based on an implementation you trust and that has been audited.
 
 <sup>[Back to top ^][title]</sup>
 
 ### 1. A TypeScript Implementation Using TweetNaCl.js
 
-The following examples use the popular [TweetNaCl.js][tweetnacl-js] library for cryptographic signing and verification.
+The following example use the popular [TweetNaCl.js][tweetnacl-js] library for cryptographic signing and verification.
 
-> ⚠️ **NOTE**: At the time of writing this ARC [TweetNaCl.js][tweetnacl-js] was last audited between January-February 2017, you can read the full audit report [here](https://cure53.de/tweetnacl.pdf).
+> ⚠️ **NOTE**: At the time of writing this proposal [TweetNaCl.js][tweetnacl-js] was last audited between January-February 2017, you can read the full audit report [here](https://cure53.de/tweetnacl.pdf).
 
 For creating and signing a JWT:
 
@@ -355,14 +357,15 @@ For creating and signing a JWT:
 import { decodeAddress, mnemonicToSecretKey } from 'algosdk';
 import { sign } from 'tweetnacl';
 
-const { addr, sk } = mnemonicToSecretKey('host degree host...'); // get the address and private key from the 25-word mnemonic seed phrase
+// get the address and private key from the 25-word mnemonic seed phrase
+const { addr, sk } = mnemonicToSecretKey('outside ancient world angry income move street brother patrol exist pet act banner quiz analyst gym build action dwarf direct castle coin fault absorb symptom');
 const encodedPublicKey: string = Buffer.from(decodeAddress(addr).publicKey).toString('base64url');
 const header: string = JSON.stringify({
   alg: 'EdDSA',
   crv: 'Ed25519',
   kty: 'OKP',
   typ: 'JWT',
-  x: encodedPublicKey, // FrMUY1-U6zLa5xz3r0RUmILVwqyIY30HX4JWEXTN2grk9Djs
+  x: encodedPublicKey, // 7Ad4Xw3aG1dDLbcI5In9O7Pehd9xodPMvD0dHHTxXnE
 });
 const payload: string = JSON.stringify({
   aud: 'https://api.awesome.com',
@@ -371,7 +374,7 @@ const payload: string = JSON.stringify({
   iss: 'https://dapp.awesome.com',
   jti: '22080a89-a283-48e7-96c5-87f17ce7a850',
   nbf: 1707739200,
-  sub: addr, // C2ZRIY27STVTFWXHDT326RCUTCBNLQVMRBRX2B27QJLBC5GN3IFOJ5BY5Q
+  sub: addr, // 5QDXQXYN3INVOQZNW4EOJCP5HOZ55BO7OGQ5HTF4HUORY5HRLZYYLIY7MU
 });
 const encodedHeader: string = Buffer.from(header).toString('base64url');
 const encodedPayload: string = Buffer.from(payload).toString('base64url');
@@ -383,7 +386,7 @@ const encodedSignature: string = Buffer.from(signature).toString('base64url');
 
 console.log(`json web token: ${encodedHeader}.${encodedPayload}.${encodedSignature}`);
 /*
-json web token: eyJhbGciOiJFZERTQSIsImNydiI6IkVkMjU1MTkiLCJrdHkiOiJPS1AiLCJ0eXAiOiJKV1QiLCJ4IjoiRnJNVVkxLVU2ekxhNXh6M3IwUlVtSUxWd3F5SVkzMEhYNEpXRVhUTjJncms5RGpzIn0.eyJhdWQiOiJodHRwczovL2FwaS5hd2Vzb21lLmNvbSIsImV4cCI6MTcwNzc4MjQwMCwiaWF0IjoxNzA3Njk2MDAwLCJpc3MiOiJodHRwczovL2RhcHAuYXdlc29tZS5jb20iLCJqdGkiOiIyMjA4MGE4OS1hMjgzLTQ4ZTctOTZjNS04N2YxN2NlN2E4NTAiLCJuYmYiOjE3MDc3MzkyMDAsInN1YiI6IkMyWlJJWTI3U1RWVEZXWEhEVDMyNlJDVVRDQk5MUVZNUkJSWDJCMjdRSkxCQzVHTjNJRk9KNUJZNVEifQ.wRUxp_9qLAutcXpzVaxKZpe3foQfQU2CDsIQZLXvVadhpDFN52ZYDHq3hk4C7bw65DetjRiaCCsPzj86I-QjDg==
+json web token: eyJhbGciOiJFZERTQSIsImNydiI6IkVkMjU1MTkiLCJrdHkiOiJPS1AiLCJ0eXAiOiJKV1QiLCJ4IjoiN0FkNFh3M2FHMWRETGJjSTVJbjlPN1BlaGQ5eG9kUE12RDBkSEhUeFhuRSJ9.eyJhdWQiOlsiaHR0cHM6Ly9hcGkuYXdlc29tZS5jb20iXSwiZXhwIjoiMjAyNC0wMi0xM1QwMDowMDowMFoiLCJqdGkiOiIyMjA4MGE4OS1hMjgzLTQ4ZTctOTZjNS04N2YxN2NlN2E4NTAiLCJpYXQiOiIyMDI0LTAyLTEyVDAwOjAwOjAwWiIsImlzcyI6Imh0dHBzOi8vZGFwcC5hd2Vzb21lLmNvbSIsIm5iZiI6IjIwMjQtMDItMTJUMTI6MDA6MDBaIiwic3ViIjoiNVFEWFFYWU4zSU5WT1FaTlc0RU9KQ1A1SE9aNTVCTzdPR1E1SFRGNEhVT1JZNUhSTFpZWUxJWTdNVSJ9.5S2MHI8LPC2cy5yv3ISNgulaEhpVk22JKyNxKi2J_uuqWCMacHgs27RuVlQbyipFlbc7z0p3AiRtxFcK8j-FCw
  */
 ```
 
@@ -399,7 +402,7 @@ const decodedSignature: Uint8Array = Buffer.from(encodedSignature, 'base64url');
 const { x } = JSON.parse(decodedHeader.toString()); // get the "x" parameter; the public key, from the header
 const decodedPublicKey: Uint8Array = Buffer.from(x, 'base64url');
 const isVerified: boolean = sign.detached.verify(
-  new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`), // re-create the signed message
+  new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`), // re-create the jose header that was signed using the token's encoded header and payload
   decodedSignature,
   decodedPublicKey,
 );
@@ -414,7 +417,7 @@ is verified: true
 
 ### 2. A Golang Implementation
 
-The following examples use the native crypto libraries.
+The following example uses golang's native crypto libraries.
 
 For creating and signing a JWT:
 
@@ -449,20 +452,21 @@ type RegisteredClaims struct {
 	Subject   string    `json:"sub,omitempty"`
 }
 
-func main() {
-	// get private key from the 25-word mnemonic seed phrase
+func main() string {
+	// get the address and private key from the 25-word mnemonic seed phrase
 	privateKey, err := mnemonic.ToPrivateKey("outside ancient world angry income move street brother patrol exist pet act banner quiz analyst gym build action dwarf direct castle coin fault absorb symptom")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-    // get the account from the private key
 	account, err := crypto.AccountFromPrivateKey(privateKey)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// encode the public in base64 url safe (without padding)
+	address := account.Address.String()
+
+	// encode the public in base64 url safe
 	encodedPublicKey := base64.RawURLEncoding.EncodeToString(privateKey.Public().(ed25519.PublicKey))
 
 	header, err := json.Marshal(Header{
@@ -476,7 +480,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// encode the header in base64 url safe (without padding)
+	// encode the header in base64 url safe
 	encodedHeader := base64.RawURLEncoding.EncodeToString(header)
 
 	payload, err := json.Marshal(RegisteredClaims{
@@ -486,13 +490,13 @@ func main() {
 		IssuedAt:  time.Unix(1707696000, 0),
 		Issuer:    "https://dapp.awesome.com",
 		NotBefore: time.Unix(1707739200, 0),
-		Subject:   account.Address.String(), // 5QDXQXYN3INVOQZNW4EOJCP5HOZ55BO7OGQ5HTF4HUORY5HRLZYYLIY7MU
+		Subject:   address, // 5QDXQXYN3INVOQZNW4EOJCP5HOZ55BO7OGQ5HTF4HUORY5HRLZYYLIY7MU
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// encode the payload in base64 url safe (without padding)
+	// encode the payload in base64 url safe
 	encodedPayload := base64.RawURLEncoding.EncodeToString(payload)
 
 	signature := ed25519.Sign(
@@ -500,38 +504,93 @@ func main() {
 		[]byte(fmt.Sprintf("%s.%s", encodedHeader, encodedPayload)),
 	)
 
-	// encode the signature in base64 url safe (without padding)
+	// encode the signature in base64 url safe
 	encodedSignature := base64.RawURLEncoding.EncodeToString(signature)
 
-	fmt.Println(fmt.Sprintf("json web token: %s.%s.%s", encodedHeader, encodedPayload, encodedSignature))
-    
-    /*
-    json web token: eyJhbGciOiJFZERTQSIsImNydiI6IkVkMjU1MTkiLCJrdHkiOiJPS1AiLCJ0eXAiOiJKV1QiLCJ4IjoiN0FkNFh3M2FHMWRETGJjSTVJbjlPN1BlaGQ5eG9kUE12RDBkSEhUeFhuRSJ9.eyJhdWQiOlsiaHR0cHM6Ly9hcGkuYXdlc29tZS5jb20iXSwiZXhwIjoiMjAyNC0wMi0xMlQxNzowMDowMC0wNzowMCIsImp0aSI6IjIyMDgwYTg5LWEyODMtNDhlNy05NmM1LTg3ZjE3Y2U3YTg1MCIsImlhdCI6IjIwMjQtMDItMTFUMTc6MDA6MDAtMDc6MDAiLCJpc3MiOiJodHRwczovL2RhcHAuYXdlc29tZS5jb20iLCJuYmYiOiIyMDI0LTAyLTEyVDA1OjAwOjAwLTA3OjAwIiwic3ViIjoiNVFEWFFYWU4zSU5WT1FaTlc0RU9KQ1A1SE9aNTVCTzdPR1E1SFRGNEhVT1JZNUhSTFpZWUxJWTdNVSJ9.rvjPcpNLnqXKHNMAjwTF41dp_eQ5pHM8ICEgAHbdFeqbGZZw48aMmHAd6MWTlS_XHvhmX0GXt4qXtT787XNSCA
+	token := fmt.Sprintf("%s.%s.%s", encodedHeader, encodedPayload, encodedSignature)
+
+	fmt.Println(fmt.Sprintf("json web token: %s", token))
+
+	/*
+	   json web token: eyJhbGciOiJFZERTQSIsImNydiI6IkVkMjU1MTkiLCJrdHkiOiJPS1AiLCJ0eXAiOiJKV1QiLCJ4IjoiN0FkNFh3M2FHMWRETGJjSTVJbjlPN1BlaGQ5eG9kUE12RDBkSEhUeFhuRSJ9.eyJhdWQiOlsiaHR0cHM6Ly9hcGkuYXdlc29tZS5jb20iXSwiZXhwIjoiMjAyNC0wMi0xM1QwMDowMDowMFoiLCJqdGkiOiIyMjA4MGE4OS1hMjgzLTQ4ZTctOTZjNS04N2YxN2NlN2E4NTAiLCJpYXQiOiIyMDI0LTAyLTEyVDAwOjAwOjAwWiIsImlzcyI6Imh0dHBzOi8vZGFwcC5hd2Vzb21lLmNvbSIsIm5iZiI6IjIwMjQtMDItMTJUMTI6MDA6MDBaIiwic3ViIjoiNVFEWFFYWU4zSU5WT1FaTlc0RU9KQ1A1SE9aNTVCTzdPR1E1SFRGNEhVT1JZNUhSTFpZWUxJWTdNVSJ9.5S2MHI8LPC2cy5yv3ISNgulaEhpVk22JKyNxKi2J_uuqWCMacHgs27RuVlQbyipFlbc7z0p3AiRtxFcK8j-FCw
 	*/
 }
 ```
 
-To verify the JWT:
+Following on from the above example, we can add a simple function to verify the token:
 
-```
-import { decodeAddress, mnemonicToSecretKey } from 'algosdk';
-import { sign } from 'tweetnacl';
+```golang
+package main
 
-const [encodedHeader, encodedPayload, encodedSignature] = jwt.split('.');
-const decodedHeader: Uint8Array = Buffer.from(encodedHeader, 'base64url');
-const decodedSignature: Uint8Array = Buffer.from(encodedSignature, 'base64url');
-const { x } = JSON.parse(decodedHeader.toString()); // get the "x" parameter; the public key, from the header
-const decodedPublicKey: Uint8Array = Buffer.from(x, 'base64url');
-const isVerified: boolean = sign.detached.verify(
-  new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`), // re-create the signed message
-  decodedSignature,
-  decodedPublicKey,
-);
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	// ...
+	"github.com/algorand/go-algorand-sdk/v2/types"
+	"golang.org/x/crypto/ed25519"
+	"log"
+	"strings"
+)
 
-console.log('is verified: ', isVerified);
-/*
-is verified: true
- */
+type Header struct {
+	Algorithm string `json:"alg"`
+	Curve     string `json:"crv,omitempty"`
+	KeyType   string `json:"kty,omitempty"`
+	Type      string `json:"typ,omitempty"`
+	PublicKey string `json:"x"`
+}
+// ...
+
+func main() {
+    // ...
+    
+    isVerified := verify(address, token)
+
+	fmt.Println(fmt.Sprintf("is verified: %t", isVerified))
+	/*
+	   is verified: true
+	*/
+}
+
+func verify(address string, token string) bool {
+	var decodedHeaderAddress types.Address
+	var header Header
+
+	tokenParts := strings.Split(token, ".")
+	decodedHeader, err := base64.RawURLEncoding.DecodeString(tokenParts[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+	decodedSignature, err := base64.RawURLEncoding.DecodeString(tokenParts[2])
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = json.Unmarshal(decodedHeader, &header)
+	if err != nil {
+		log.Fatal(err)
+	}
+	decodedPublicKey, err := base64.RawURLEncoding.DecodeString(header.PublicKey) // get the raw public key; the "x" parameter, from the header
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// get the address from the header's public key
+	copy(decodedHeaderAddress[:], decodedPublicKey)
+
+    // ensure the address in the header matches an address you specify (e.g. this could be a user of your platform)
+	if address != decodedHeaderAddress.String() {
+      fmt.Println(fmt.Sprintf("json invalid expected address '%s' but received '%s'", address, decodedHeaderAddress))
+    
+      return false
+	}
+
+	return ed25519.Verify(
+		decodedPublicKey,
+		[]byte(fmt.Sprintf("%s.%s", tokenParts[0], tokenParts[1])), // re-create the jose header that was signed using the header and payload
+		decodedSignature,
+	)
+}
 ```
 
 <sup>[Back to top ^][title]</sup>
@@ -555,6 +614,7 @@ Copyright and related rights waived via <a href="https://creativecommons.org/pub
 [rfc-4122]: https://datatracker.ietf.org/doc/html/rfc4122
 [rfc-4648-section-5]: https://datatracker.ietf.org/doc/html/rfc4648#section-5
 [rfc-4648-section-6]: https://datatracker.ietf.org/doc/html/rfc4648#section-6
+[rfc-7515-section-3]: https://datatracker.ietf.org/doc/html/rfc7515#section-3
 [rfc-7515-section-411]: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.1
 [rfc-7519]: https://datatracker.ietf.org/doc/html/rfc7519
 [rfc-7519-section-411]: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1

--- a/ARCs/arc-0080.md
+++ b/ARCs/arc-0080.md
@@ -412,6 +412,130 @@ is verified: true
 
 <sup>[Back to top ^][title]</sup>
 
+### 2. A Golang Implementation
+
+The following examples use the native crypto libraries.
+
+For creating and signing a JWT:
+
+```golang
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/algorand/go-algorand-sdk/v2/crypto"
+	"github.com/algorand/go-algorand-sdk/v2/mnemonic"
+	"golang.org/x/crypto/ed25519"
+	"log"
+	"time"
+)
+
+type Header struct {
+	Algorithm string `json:"alg"`
+	Curve     string `json:"crv,omitempty"`
+	KeyType   string `json:"kty,omitempty"`
+	Type      string `json:"typ,omitempty"`
+	PublicKey string `json:"x"`
+}
+type RegisteredClaims struct {
+	Audience  []string  `json:"aud,omitempty"`
+	ExpiresAt time.Time `json:"exp,omitempty"`
+	ID        string    `json:"jti,omitempty"`
+	IssuedAt  time.Time `json:"iat,omitempty"`
+	Issuer    string    `json:"iss,omitempty"`
+	NotBefore time.Time `json:"nbf,omitempty"`
+	Subject   string    `json:"sub,omitempty"`
+}
+
+func main() {
+	// get private key from the 25-word mnemonic seed phrase
+	privateKey, err := mnemonic.ToPrivateKey("outside ancient world angry income move street brother patrol exist pet act banner quiz analyst gym build action dwarf direct castle coin fault absorb symptom")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+    // get the account from the private key
+	account, err := crypto.AccountFromPrivateKey(privateKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// encode the public in base64 url safe (without padding)
+	encodedPublicKey := base64.RawURLEncoding.EncodeToString(privateKey.Public().(ed25519.PublicKey))
+
+	header, err := json.Marshal(Header{
+		Algorithm: "EdDSA",
+		Curve:     "Ed25519",
+		KeyType:   "OKP",
+		Type:      "JWT",
+		PublicKey: encodedPublicKey,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// encode the header in base64 url safe (without padding)
+	encodedHeader := base64.RawURLEncoding.EncodeToString(header)
+
+	payload, err := json.Marshal(RegisteredClaims{
+		Audience:  []string{"https://api.awesome.com"},
+		ExpiresAt: time.Unix(1707782400, 0),
+		ID:        "22080a89-a283-48e7-96c5-87f17ce7a850",
+		IssuedAt:  time.Unix(1707696000, 0),
+		Issuer:    "https://dapp.awesome.com",
+		NotBefore: time.Unix(1707739200, 0),
+		Subject:   account.Address.String(), // 5QDXQXYN3INVOQZNW4EOJCP5HOZ55BO7OGQ5HTF4HUORY5HRLZYYLIY7MU
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// encode the payload in base64 url safe (without padding)
+	encodedPayload := base64.RawURLEncoding.EncodeToString(payload)
+
+	signature := ed25519.Sign(
+		privateKey, // sign with the algorand account's private key
+		[]byte(fmt.Sprintf("%s.%s", encodedHeader, encodedPayload)),
+	)
+
+	// encode the signature in base64 url safe (without padding)
+	encodedSignature := base64.RawURLEncoding.EncodeToString(signature)
+
+	fmt.Println(fmt.Sprintf("json web token: %s.%s.%s", encodedHeader, encodedPayload, encodedSignature))
+    
+    /*
+    json web token: eyJhbGciOiJFZERTQSIsImNydiI6IkVkMjU1MTkiLCJrdHkiOiJPS1AiLCJ0eXAiOiJKV1QiLCJ4IjoiN0FkNFh3M2FHMWRETGJjSTVJbjlPN1BlaGQ5eG9kUE12RDBkSEhUeFhuRSJ9.eyJhdWQiOlsiaHR0cHM6Ly9hcGkuYXdlc29tZS5jb20iXSwiZXhwIjoiMjAyNC0wMi0xMlQxNzowMDowMC0wNzowMCIsImp0aSI6IjIyMDgwYTg5LWEyODMtNDhlNy05NmM1LTg3ZjE3Y2U3YTg1MCIsImlhdCI6IjIwMjQtMDItMTFUMTc6MDA6MDAtMDc6MDAiLCJpc3MiOiJodHRwczovL2RhcHAuYXdlc29tZS5jb20iLCJuYmYiOiIyMDI0LTAyLTEyVDA1OjAwOjAwLTA3OjAwIiwic3ViIjoiNVFEWFFYWU4zSU5WT1FaTlc0RU9KQ1A1SE9aNTVCTzdPR1E1SFRGNEhVT1JZNUhSTFpZWUxJWTdNVSJ9.rvjPcpNLnqXKHNMAjwTF41dp_eQ5pHM8ICEgAHbdFeqbGZZw48aMmHAd6MWTlS_XHvhmX0GXt4qXtT787XNSCA
+	*/
+}
+```
+
+To verify the JWT:
+
+```
+import { decodeAddress, mnemonicToSecretKey } from 'algosdk';
+import { sign } from 'tweetnacl';
+
+const [encodedHeader, encodedPayload, encodedSignature] = jwt.split('.');
+const decodedHeader: Uint8Array = Buffer.from(encodedHeader, 'base64url');
+const decodedSignature: Uint8Array = Buffer.from(encodedSignature, 'base64url');
+const { x } = JSON.parse(decodedHeader.toString()); // get the "x" parameter; the public key, from the header
+const decodedPublicKey: Uint8Array = Buffer.from(x, 'base64url');
+const isVerified: boolean = sign.detached.verify(
+  new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`), // re-create the signed message
+  decodedSignature,
+  decodedPublicKey,
+);
+
+console.log('is verified: ', isVerified);
+/*
+is verified: true
+ */
+```
+
+<sup>[Back to top ^][title]</sup>
+
 ## Security Considerations
 
 None.
@@ -426,6 +550,7 @@ Copyright and related rights waived via <a href="https://creativecommons.org/pub
 <!-- links -->
 [iana-jwa-list]: https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms
 [algorand-keys-and-addresses]: https://developer.algorand.org/docs/get-details/accounts/#keys-and-addresses
+[golang-jwt]: https://github.com/golang-jwt/jwt
 [rfc-3986]: https://datatracker.ietf.org/doc/html/rfc3986
 [rfc-4122]: https://datatracker.ietf.org/doc/html/rfc4122
 [rfc-4648-section-5]: https://datatracker.ietf.org/doc/html/rfc4648#section-5

--- a/ARCs/arc-0080.md
+++ b/ARCs/arc-0080.md
@@ -1,15 +1,15 @@
 ---
 arc: 80
 title: JSON Web Tokens (JWT) Using An Algorand Account
-description: A specification that outlines using a JSON Web Tokens (JWT) within the context of an Algorand account.
+description: A specification that outlines using JSON Web Tokens (JWT) within the context of an Algorand account.
 author: Kieran O'Neill (@kieranroneill)
 status: Draft
 type: Standards Track
 category: Interface
-created: 2024-02-12
+created: 2024-09-10
 ---
 
-# Authentication with JSON Web Token (JWT)
+# JSON Web Tokens (JWT) Using An Algorand Account
 
 ## Abstract
 


### PR DESCRIPTION
## Summary

JSON Web Tokens (JWTs) are a popular and well-used format to represent a claim between two parties. They use cryptographic signatures to verify these claims and, thanks to [RFC 8037](https://datatracker.ietf.org/doc/html/rfc8037), JWTs support the Ed25519 signature: the cryptographic algorithm of the private keys of Algorand accounts. Therefore, JWTs are well-suited and a viable way to be using for authentication within the context of an Algorand account. 

The purpose of this proposal is to highlight how to construct a JWT with a Ed25519 public/private key pair using already well-established standards. This proposal also makes some suggestions as to the structure of the claims within the context of a an Algorand account.
