### PR TITLE
Fix error in ARC54 total (and add addresses)

### DIFF
--- a/ARCs/arc-0054.md
+++ b/ARCs/arc-0054.md
@@ -201,9 +201,11 @@ class ARC54 extends Contract {
 
 An application per the above reference implementation has been deployed to each of Algorand's networks at these app IDs:
 
-- MainNet: 1257620981
-- TestNet: 497806551
-- BetaNet: 2019020358
+| Network | App ID | Address |
+| --- | --- | --- |
+| MainNet | 1257620981 | BNFIREKGRXEHCFOEQLTX3PU5SUCMRKDU7WHNBGZA4SXPW42OAHZBP7BPHY |
+| TestNet | 497806551 | 3TKF2GMZJ5VZ4BQVQGC72BJ63WFN4QBPU2EUD4NQYHFLC3NE5D7GXHXYOQ |
+| BetaNet | 2019020358 | XRXCALSRDVUY2OQXWDYCRMHPCF346WKIV5JPAHXQ4MZADSROJGDIHZP7AI |
 
 ## Security Considerations
 It should be noted that once an asset is sent to the contract there will be no way to recover the asset unless it has clawback enabled.

--- a/ARCs/arc-0054.md
+++ b/ARCs/arc-0054.md
@@ -22,7 +22,7 @@ It is important to note that assets with clawback enabled are effectively imposs
 
 | Token Type | Clawback | No Clawback |
 | ---------- | -------- | ----------- |
-| Total Supply | Total | Total - Qty in burn address |
+| Total Supply | Total | Total |
 | Circulating Supply | Total - Qty in Reserve Address - Qty in burn address | Total - Qty in Reserve Address - Qty in burn address |
 | Available Supply | Total | Total - Qty in burn address |
 | Burned Supply | N/A (Impossible to burn) | Qty in burn address |


### PR DESCRIPTION
Both @SilentRhetoric and myself agree that this was an error in the ARC. Total supply should *not* remove the burned supply. This metric is captured via `Available` supply. 

Also added in addresses to the deployments. 