### PR TITLE
ARC-2 How to handle ARC data inside a note

### DIFF
--- a/ARCs/arc-0002.md
+++ b/ARCs/arc-0002.md
@@ -2,7 +2,7 @@
 arc: 2
 title: Algorand Transaction Note Field Conventions
 description: Conventions for encoding data in the note field at application-level
-author: Fabrice Benhamouda (@fabrice102)
+author: Fabrice Benhamouda (@fabrice102), Stéphane BARROSO (@SudoWeezy), Cosimo BASSI (@cusma)
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/2
 status: Final
 type: Standards Track
@@ -41,12 +41,9 @@ where:
     * Names starting with `a/` and `af/` are reserved for the Algorand protocol and the Algorand Foundation uses.
 
 - `<arc-number>` is the number of the ARC with 0 padding:
-  - Regexp to satisfy: `0\d{3}|\d{4}`
-  - Only contain a four-digit number, either zero-padded or not, matching:
-    - 0\d{3} for zero-padded numbers (e.g., 0001, 0456).
-    - \d{4} for non-padded four-digit numbers (e.g., 1234, 5678).
-    - Be exactly four digits long.
-
+  - Regexp to satisfy: `\b(0|[1-9]\d*)\b`:
+      - Only contain a digit number, without any padding
+  
 * `<data-format>` is one of the following:
     * `m`: <a href="https://msgpack.org">MsgPack</a>
     * `j`: <a href="https://json.org">JSON</a>

--- a/ARCs/arc-0002.md
+++ b/ARCs/arc-0002.md
@@ -87,6 +87,15 @@ The restrictions on dApp names were chosen to allow most usual names while avoid
 
 > This section is non-normative.
 
+Consider ARC-20, that provides information about Smart ASA's Application.
+
+Here a potential note indicating that the Application ID is 123:
+
+* JSON without version:
+    ```
+    arc20:j{"application-id":123}
+    ```
+
 Consider a dApp named `algoCityTemp` that stores temperatures from cities on the blockchain.
 
 Here are some potential notes indicating that Singapore's temperature is 35 degree Celsius:

--- a/ARCs/arc-0002.md
+++ b/ARCs/arc-0002.md
@@ -87,7 +87,7 @@ The restrictions on dApp names were chosen to allow most usual names while avoid
 
 > This section is non-normative.
 
-Consider [ARC-20]('./arc-0020.md'), that provides information about Smart ASA's Application.
+Consider [ARC-20](./arc-0020.md), that provides information about Smart ASA's Application.
 
 Here a potential note indicating that the Application ID is 123:
 

--- a/ARCs/arc-0002.md
+++ b/ARCs/arc-0002.md
@@ -40,10 +40,11 @@ where:
          * be at most 32 characters long
     * Names starting with `a/` and `af/` are reserved for the Algorand protocol and the Algorand Foundation uses.
 
-- `<arc-number>` is the number of the ARC:
-  - Regexp to satisfy: `\b(0|[1-9]\d*)\b`:
-      - Only contain a digit number, without any 0 padding
-  
+* `<arc-number>` is the number of the ARC:
+    * Regexp to satisfy: `\b(0|[1-9]\d*)\b`
+      In other words, an arc-number should:
+        * Only contain a digit number, without any padding
+
 * `<data-format>` is one of the following:
     * `m`: <a href="https://msgpack.org">MsgPack</a>
     * `j`: <a href="https://json.org">JSON</a>

--- a/ARCs/arc-0002.md
+++ b/ARCs/arc-0002.md
@@ -87,7 +87,7 @@ The restrictions on dApp names were chosen to allow most usual names while avoid
 
 > This section is non-normative.
 
-Consider ARC-20, that provides information about Smart ASA's Application.
+Consider [ARC-20]('./arc-0020.md'), that provides information about Smart ASA's Application.
 
 Here a potential note indicating that the Application ID is 123:
 

--- a/ARCs/arc-0002.md
+++ b/ARCs/arc-0002.md
@@ -33,6 +33,9 @@ where:
          * be at least 5 characters long
          * be at most 32 characters long
     * Names starting with `a/` and `af/` are reserved for the Algorand protocol and the Algorand Foundation uses.
+
+<!-- Todo -->
+
 * `<data-format>` is one of the following:
     * `m`: <a href="https://msgpack.org">MsgPack</a>
     * `j`: <a href="https://json.org">JSON</a>

--- a/ARCs/arc-0002.md
+++ b/ARCs/arc-0002.md
@@ -40,9 +40,9 @@ where:
          * be at most 32 characters long
     * Names starting with `a/` and `af/` are reserved for the Algorand protocol and the Algorand Foundation uses.
 
-- `<arc-number>` is the number of the ARC with 0 padding:
+- `<arc-number>` is the number of the ARC:
   - Regexp to satisfy: `\b(0|[1-9]\d*)\b`:
-      - Only contain a digit number, without any padding
+      - Only contain a digit number, without any 0 padding
   
 * `<data-format>` is one of the following:
     * `m`: <a href="https://msgpack.org">MsgPack</a>

--- a/ARCs/arc-0002.md
+++ b/ARCs/arc-0002.md
@@ -20,8 +20,14 @@ The goal of these conventions is to make it simpler for block explorers and inde
 
 Note fields should be formatted as follows:
 
+for dApps
 ```
 <dapp-name>:<data-format><data>
+```
+
+for ARCs
+```
+arc<arc-number>:<data-format><data>
 ```
 
 where:
@@ -34,7 +40,12 @@ where:
          * be at most 32 characters long
     * Names starting with `a/` and `af/` are reserved for the Algorand protocol and the Algorand Foundation uses.
 
-<!-- Todo -->
+- `<arc-number>` is the number of the ARC with 0 padding:
+  - Regexp to satisfy: `0\d{3}|\d{4}`
+  - Only contain a four-digit number, either zero-padded or not, matching:
+    - 0\d{3} for zero-padded numbers (e.g., 0001, 0456).
+    - \d{4} for non-padded four-digit numbers (e.g., 1234, 5678).
+    - Be exactly four digits long.
 
 * `<data-format>` is one of the following:
     * `m`: <a href="https://msgpack.org">MsgPack</a>
@@ -43,7 +54,9 @@ where:
     * `u`: utf-8 string
 * `<data>` is the actual data in the format specified by `<data-format>`
 
-**WARNING**: Any user can create transactions with arbitrary data and may impersonate other dApps. In particular, the fact that a note field start with `<dapp-name>` does not guarantee that it indeed comes from this dApp. The value `<dapp-name>` cannot be relied upon to ensure provenance and validity of the `<data>`. 
+**WARNING**: Any user can create transactions with arbitrary data and may impersonate other dApps. In particular, the fact that a note field start with `<dapp-name>` does not guarantee that it indeed comes from this dApp. The value `<dapp-name>` cannot be relied upon to ensure provenance and validity of the `<data>`.
+
+**WARNING**: Any user can create transactions with arbitrary data, including arc numbers, which may not correspond to the intended standard. An arc number included in a note field does not ensure compliance with the corresponding standard. The value of the arc number cannot be relied upon to ensure the provenance and validity of the <data>.
 
 ### Versioning
 
@@ -76,7 +89,7 @@ The restrictions on dApp names were chosen to allow most usual names while avoid
 
 > This section is non-normative.
 
-Consider a dApp named `algoCityTemp` that stores temperatures from cities on the blockchain. 
+Consider a dApp named `algoCityTemp` that stores temperatures from cities on the blockchain.
 
 Here are some potential notes indicating that Singapore's temperature is 35 degree Celsius:
 * JSON without version:

--- a/ARCs/arc-0002.md
+++ b/ARCs/arc-0002.md
@@ -2,7 +2,7 @@
 arc: 2
 title: Algorand Transaction Note Field Conventions
 description: Conventions for encoding data in the note field at application-level
-author: Fabrice Benhamouda (@fabrice102), Stéphane BARROSO (@SudoWeezy), Cosimo BASSI (@cusma)
+author: Fabrice Benhamouda (@fabrice102), Stéphane Barroso (@SudoWeezy), Cosimo Bassi (@cusma)
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/2
 status: Final
 type: Standards Track
@@ -54,7 +54,7 @@ where:
 
 **WARNING**: Any user can create transactions with arbitrary data and may impersonate other dApps. In particular, the fact that a note field start with `<dapp-name>` does not guarantee that it indeed comes from this dApp. The value `<dapp-name>` cannot be relied upon to ensure provenance and validity of the `<data>`.
 
-**WARNING**: Any user can create transactions with arbitrary data, including arc numbers, which may not correspond to the intended standard. An arc number included in a note field does not ensure compliance with the corresponding standard. The value of the arc number cannot be relied upon to ensure the provenance and validity of the <data>.
+**WARNING**: Any user can create transactions with arbitrary data, including ARC numbers, which may not correspond to the intended standard. An ARC number included in a note field does not ensure compliance with the corresponding standard. The value of the ARC number cannot be relied upon to ensure the provenance and validity of the <data>.
 
 ### Versioning
 


### PR DESCRIPTION
We would like to have a more precise version of how to read notes related to ARCs.

Here is a little list of options we have in mind:

1. `af/arc:j{<N1>:{...}, <N2>:{...}, ...}` (no 0 padding for <N>), allows multiple ARCs in one note field, harder to parse (maybe) 
1. `af/arc<N>:j{...}` (no 0 padding for <N>) single ARC per note field, maybe easier to fetch and parse 
1. `arc<N>:j{...}` (with 0 padding for <N>) single ARC per note field, maybe easier to fetch and parse