### PR TITLE
Deprecating ARCs 6-7-8-9-10-11-15

### DIFF
--- a/ARCs/arc-0006.md
+++ b/ARCs/arc-0006.md
@@ -4,10 +4,11 @@ title: Algorand Wallet Address Discovery API
 description: API function, enable, which allows the discovery of accounts
 author: DanBurton (@DanBurton)
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/52
-status: Final
+status: Deprecated
 type: Standards Track
 category: Interface
 created: 2021-08-09
+superseded-by:
 ---
 
 # Algorand Wallet Address Discovery API

--- a/ARCs/arc-0007.md
+++ b/ARCs/arc-0007.md
@@ -4,10 +4,11 @@ title: Algorand Wallet Post Transactions API
 description: API function to Post Signed Transactions to the network.
 author: DanBurton (@DanBurton)
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/52
-status: Final
+status: Deprecated
 type: Standards Track
 category: Interface
 created: 2021-08-09
+superseded-by:
 ---
 
 # Algorand Wallet Post Transactions API

--- a/ARCs/arc-0008.md
+++ b/ARCs/arc-0008.md
@@ -4,10 +4,11 @@ title: Algorand Wallet Sign and Post API
 description: A function used to simultaneously sign and post transactions to the network.
 author: DanBurton (@DanBurton)
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/52
-status: Final
+status: Deprecated
 type: Standards Track
 category: Interface
 created: 2021-08-09
+superseded-by:
 ---
 
 # Algorand Wallet Sign and Post API

--- a/ARCs/arc-0009.md
+++ b/ARCs/arc-0009.md
@@ -4,10 +4,11 @@ title: Algorand Wallet Algodv2 and Indexer API
 description: An API for accessing Algod and Indexer through a user's preferred connection.
 author: DanBurton (@DanBurton)
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/52
-status: Final
+status: Deprecated
 type: Standards Track
 category: Interface
 created: 2021-08-09
+superseded-by:
 ---
 
 # Algorand Wallet Algodv2 and Indexer API

--- a/ARCs/arc-0010.md
+++ b/ARCs/arc-0010.md
@@ -4,10 +4,11 @@ title: Algorand Wallet Reach Minimum Requirements
 description: Minimum requirements for Reach to function with a given wallet.
 author: DanBurton (@DanBurton)
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/52
-status: Final
+status: Deprecated
 type: Standards Track
 category: Interface
 created: 2021-08-09
+superseded-by:
 ---
 
 # Algorand Wallet Reach Minimum Requirements

--- a/ARCs/arc-0011.md
+++ b/ARCs/arc-0011.md
@@ -4,10 +4,11 @@ title: Algorand Wallet Reach Browser Spec
 description: Convention for DApps to discover Algorand wallets in browser
 author: DanBurton (@DanBurton)
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/52
-status: Final
+status: Deprecated
 type: Standards Track
 category: Interface
 created: 2021-08-09
+superseded-by:
 ---
 
 # Algorand Wallet Reach Browser Spec

--- a/ARCs/arc-0015.md
+++ b/ARCs/arc-0015.md
@@ -4,11 +4,12 @@ title: Encrypted Short Messages
 description: Scheme for encryption/decryption that allows for private messages.
 author: Stéphane Barroso (@sudoweezy), Paweł Pierścionek (@urtho)
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/*
-status: Final
+status: Deprecated
 type: Standards Track
 category: Interface
 created: 2022-11-21
 requires: 4
+superseded-by:
 ---
 
 # Encrypted Short Messages 

--- a/ARCs/arc-0076.md
+++ b/ARCs/arc-0076.md
@@ -4,7 +4,7 @@ title: Password Account
 description: Password account using PBKDF2
 author: Ludovit Scholtz (@scholtz)
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/208
-status: Deprecated
+status: Final
 type: Standards Track
 category: Core
 created: 2023-06-12

--- a/ARCs/arc-0076.md
+++ b/ARCs/arc-0076.md
@@ -8,7 +8,6 @@ status: Final
 type: Standards Track
 category: Core
 created: 2023-06-12
-superseded-by:
 ---
 
 ## Abstract

--- a/ARCs/arc-0076.md
+++ b/ARCs/arc-0076.md
@@ -4,10 +4,11 @@ title: Password Account
 description: Password account using PBKDF2
 author: Ludovit Scholtz (@scholtz)
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/208
-status: Final
+status: Deprecated
 type: Standards Track
 category: Core
 created: 2023-06-12
+superseded-by:
 ---
 
 ## Abstract


### PR DESCRIPTION
This aims to streamline the requirements for onboarding new members in our ecosystem by proposing a consensus on the deprecation of certain ARC specifications. The goal is to consolidate and simplify to better align with the current and future needs of the ecosystem.

Proposed Deprecations
The following ARCs are proposed for deprecation:

ARC-6: Algorand Wallet Address Discovery API
ARC-7: Algorand Wallet Post Transactions API
ARC-8: Algorand Wallet Sign and Post API
ARC-9: Algorand Wallet Algodv2 and Indexer API
ARC-10: Algorand Wallet Reach Minimum Requirements
ARC-11: Algorand Wallet Reach Browser Spec
ARC-15: Encrypted Short Messages 


Request for Consensus
I want to gather feedback to ensure there is a consensus on these proposed changes. Please let us know your thoughts or concerns on the deprecation of these ARCs.
