### PR TITLE
Add ABI Calls support to ARC-0026

### DIFF
--- a/ARCs/arc-0026.md
+++ b/ARCs/arc-0026.md
@@ -128,7 +128,7 @@ Request 150 units of Asset ID 45 from an address
 algorand://TMTAD6N22HCS2LKH7677L2KFLT3PAQWY6M4JFQFXQS32ECBFC23F57RYX4?amount=150&asset=45
 ```
 
-Call claim(uint64,uint64)byte[] method on contract 11111111 from an address
+Call claim(uint64,uint64)byte[] method on contract 11111111 paying a fee of 10000 micro ALGO from an address
 
 ```
 algorand://TMTAD6N22HCS2LKH7677L2KFLT3PAQWY6M4JFQFXQS32ECBFC23F57RYX4?app=11111111&method=claim(uint64,uint64)byte[]&arg=20000&arg=474567&asset=45&fee=10000

--- a/ARCs/arc-0026.md
+++ b/ARCs/arc-0026.md
@@ -27,7 +27,7 @@ Elements of the query component may contain characters outside the valid range. 
 algorandurn     = "algorand://" algorandaddress [ "?" algorandparams ]
 algorandaddress = *base32
 algorandparams  = algorandparam [ "&" algorandparams ]
-algorandparam   = [ amountparam / labelparam / noteparam / assetparam / appparam /  methodparam / argparam/ boxparam / assetarrayparam / accountarrayparam / apparrayparam / otherparam ]
+algorandparam   = [ amountparam / labelparam / noteparam / assetparam / appparam /  methodparam / argparam / boxparam / assetarrayparam / accountarrayparam / apparrayparam / otherparam ]
 amountparam     = "amount=" *digit
 labelparam      = "label=" *qchar
 assetparam      = "asset=" *digit

--- a/ARCs/arc-0026.md
+++ b/ARCs/arc-0026.md
@@ -27,19 +27,29 @@ Elements of the query component may contain characters outside the valid range. 
 algorandurn     = "algorand://" algorandaddress [ "?" algorandparams ]
 algorandaddress = *base32
 algorandparams  = algorandparam [ "&" algorandparams ]
-algorandparam   = [ amountparam / labelparam / noteparam / assetparam / otherparam ]
+algorandparam   = [ amountparam / labelparam / noteparam / assetparam / appparam /  methodparam / argparam/ assetarrayparam / accountarrayparam / apparrayparam / otherparam ]
 amountparam     = "amount=" *digit
 labelparam      = "label=" *qchar
 assetparam      = "asset=" *digit
+appparam        = "app=" *digit
 noteparam       = (xnote | note)
 xnote           = "xnote=" *qchar
-note            = "note=" *qchar
+note            = "note=" *qchar 
+methodparam     = "method=" *qchar
+argparam        = "arg=" (*qchar | *digit)
+accountarrayparam = "account=" *qchar
+assetarrayparam = "asset=" *digit
+apparrayparam   = "app=" *digit
 otherparam      = qchar *qchar [ "=" *qchar ]
 ```
 
 Here, "qchar" corresponds to valid characters of an RFC 3986 URI query component, excluding the "=" and "&" characters, which this specification takes as separators.
 
 The scheme component ("algorand:") is case-insensitive, and implementations must accept any combination of uppercase and lowercase letters. The rest of the URI is case-sensitive, including the query parameter keys.
+
+Note 1: the first `app=` in the presence of the method interprets as the destination app Id and the next ones in sequence would be considered app array members.
+
+Note 2: the `asset=` in the presence of the method interprets as an asset array member.
 
 !!! Caveat
     When it comes to generation of an address' QR,  many exchanges and wallets encodes the address w/o the scheme component (“algorand:”). This is not a URI so it is OK.
@@ -56,7 +66,15 @@ The scheme component ("algorand:") is case-insensitive, and implementations must
 
 - amount: microAlgos or smallest unit of asset 
 
-- asset: The asset id this request refers to (if Algos, simply omit this parameter) 
+- asset: The asset id this request refers to (if Algos, simply omit this parameter). When the method is available, the asset is an Asset Array member for the ABI call.
+
+- method: The full ABI method to call. E.g. claim(uint64,uint64)byte[]
+
+- arg: The argument to be added to ABI call arguments array.
+
+- app: The app id this request refers to. When method is available, first app is the destination app for ABI call and from second index app is an App Array member for ABI call.
+
+- account: The account address to add to accounts array after sender. Only when method is available.
 
 - (others): optional, for future extensions
 
@@ -99,7 +117,15 @@ Request 150 units of Asset ID 45 from an address
 algorand://TMTAD6N22HCS2LKH7677L2KFLT3PAQWY6M4JFQFXQS32ECBFC23F57RYX4?amount=150&asset=45
 ```
 
+call claim(uint64,uint64)byte[] method on contract 11111111
+
+```
+algorand://TMTAD6N22HCS2LKH7677L2KFLT3PAQWY6M4JFQFXQS32ECBFC23F57RYX4?app=11111111&method=claim(uint64,uint64)byte[]&arg=20000&arg=474567&asset=45
+```
+
 ## Rationale
+
+The addition of ARC4 support to ARC26 is a mandatory step for effective interactivity of Algorand operations with users and increases interoperability amongst users as well
 
 ## Security Considerations
 

--- a/ARCs/arc-0026.md
+++ b/ARCs/arc-0026.md
@@ -27,7 +27,7 @@ Elements of the query component may contain characters outside the valid range. 
 algorandurn     = "algorand://" algorandaddress [ "?" algorandparams ]
 algorandaddress = *base32
 algorandparams  = algorandparam [ "&" algorandparams ]
-algorandparam   = [ amountparam / labelparam / noteparam / assetparam / appparam /  methodparam / argparam/ assetarrayparam / accountarrayparam / apparrayparam / otherparam ]
+algorandparam   = [ amountparam / labelparam / noteparam / assetparam / appparam /  methodparam / argparam/ boxparam / assetarrayparam / accountarrayparam / apparrayparam / otherparam ]
 amountparam     = "amount=" *digit
 labelparam      = "label=" *qchar
 assetparam      = "asset=" *digit
@@ -36,6 +36,7 @@ noteparam       = (xnote | note)
 xnote           = "xnote=" *qchar
 note            = "note=" *qchar 
 methodparam     = "method=" *qchar
+boxparam        = "box=" *qchar
 argparam        = "arg=" (*qchar | *digit)
 accountarrayparam = "account=" *qchar
 assetarrayparam = "asset=" *digit
@@ -71,6 +72,8 @@ Note 2: the `asset=` in the presence of the method interprets as an asset array 
 - method: The full ABI method to call. E.g. claim(uint64,uint64)byte[]
 
 - arg: The argument to be added to ABI call arguments array.
+
+- box: The box name refference.
 
 - app: The app id this request refers to. When method is available, first app is the destination app for ABI call and from second index app is an App Array member for ABI call.
 

--- a/ARCs/arc-0026.md
+++ b/ARCs/arc-0026.md
@@ -38,6 +38,7 @@ note            = "note=" *qchar
 methodparam     = "method=" *qchar
 boxparam        = "box=" *qchar
 argparam        = "arg=" (*qchar | *digit)
+feeparam        = "fee=" *digit
 accountarrayparam = "account=" *qchar
 assetarrayparam = "asset=" *digit
 apparrayparam   = "app=" *digit
@@ -73,7 +74,9 @@ Note 2: the `asset=` in the presence of the method interprets as an asset array 
 
 - arg: The argument to be added to ABI call arguments array.
 
-- box: The box name refference.
+- box: The box name reference.
+
+- fee: Optional static transaction fee.
 
 - app: The app id this request refers to. When method is available, first app is the destination app for ABI call and from second index app is an App Array member for ABI call.
 
@@ -123,7 +126,7 @@ algorand://TMTAD6N22HCS2LKH7677L2KFLT3PAQWY6M4JFQFXQS32ECBFC23F57RYX4?amount=150
 Call claim(uint64,uint64)byte[] method on contract 11111111 from an address
 
 ```
-algorand://TMTAD6N22HCS2LKH7677L2KFLT3PAQWY6M4JFQFXQS32ECBFC23F57RYX4?app=11111111&method=claim(uint64,uint64)byte[]&arg=20000&arg=474567&asset=45
+algorand://TMTAD6N22HCS2LKH7677L2KFLT3PAQWY6M4JFQFXQS32ECBFC23F57RYX4?app=11111111&method=claim(uint64,uint64)byte[]&arg=20000&arg=474567&asset=45&fee=10000
 ```
 
 ## Rationale

--- a/ARCs/arc-0026.md
+++ b/ARCs/arc-0026.md
@@ -128,7 +128,7 @@ algorand://TMTAD6N22HCS2LKH7677L2KFLT3PAQWY6M4JFQFXQS32ECBFC23F57RYX4?app=111111
 
 ## Rationale
 
-The addition of ARC4 support to ARC26 is a mandatory step for effective interactivity of Algorand operations with users and increases interoperability amongst users as well
+
 
 ## Security Considerations
 

--- a/ARCs/arc-0026.md
+++ b/ARCs/arc-0026.md
@@ -78,7 +78,7 @@ Note 3: The account address in case of method presence is the Sender account not
 
 - box: The box name reference.
 
-- fee: Optional static transaction fee.
+- fee: Optional static transaction fee (in MicroAlgos)
 
 - app: The app id this request refers to. When method is available, first app is the destination app for ABI call and from second index app is an App Array member for ABI call.
 

--- a/ARCs/arc-0026.md
+++ b/ARCs/arc-0026.md
@@ -120,7 +120,7 @@ Request 150 units of Asset ID 45 from an address
 algorand://TMTAD6N22HCS2LKH7677L2KFLT3PAQWY6M4JFQFXQS32ECBFC23F57RYX4?amount=150&asset=45
 ```
 
-call claim(uint64,uint64)byte[] method on contract 11111111
+Call claim(uint64,uint64)byte[] method on contract 11111111 from an address
 
 ```
 algorand://TMTAD6N22HCS2LKH7677L2KFLT3PAQWY6M4JFQFXQS32ECBFC23F57RYX4?app=11111111&method=claim(uint64,uint64)byte[]&arg=20000&arg=474567&asset=45

--- a/ARCs/arc-0026.md
+++ b/ARCs/arc-0026.md
@@ -49,9 +49,11 @@ Here, "qchar" corresponds to valid characters of an RFC 3986 URI query component
 
 The scheme component ("algorand:") is case-insensitive, and implementations must accept any combination of uppercase and lowercase letters. The rest of the URI is case-sensitive, including the query parameter keys.
 
-Note 1: the first `app=` in the presence of the method interprets as the destination app Id and the next ones in sequence would be considered app array members.
+Note 1: the first `app=` in the presence of the method interprets as the destination app ID and the next ones in sequence would be considered app array members.
 
 Note 2: the `asset=` in the presence of the method interprets as an asset array member.
+
+Note 3: The account address in case of method presence is the Sender account not the destination recipient as it is the case with all Algorand URIs without method.
 
 !!! Caveat
     When it comes to generation of an address' QR,  many exchanges and wallets encodes the address w/o the scheme component (“algorand:”). This is not a URI so it is OK.
@@ -83,6 +85,9 @@ Note 2: the `asset=` in the presence of the method interprets as an asset array 
 - account: The account address to add to accounts array after sender. Only when method is available.
 
 - (others): optional, for future extensions
+
+### Template URI vs actionable URI
+If the URI is constructed for templating only so that other dApps, wallets or protocols could user it for any user then the account address in URI must be ZeroAddress ("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ"). Since ZeroAddress cannot initiate any action this assumption is considered non-vulnerable and secure.
 
 ### Transfer amount/size
 


### PR DESCRIPTION
ABI Calls are a necessary building block for decentralized SOA interoperability and user-chain interaction. The support is included in this PR.