### PR TITLE
ARC-0 Add Tracking mechanism for extension

### DIFF
--- a/ARCs/arc-0000.md
+++ b/ARCs/arc-0000.md
@@ -150,8 +150,8 @@ Each ARC must begin with an <a href="https://www.ietf.org/rfc/rfc822.txt">RFC 82
 >ARCs may also have a `superseded-by` header indicating that an ARC has been rendered obsolete by a later document; the value is the number of the ARC that replaces the current document.
 >The newer ARC must have a `replaces` header containing the number of the ARC that it rendered obsolete.
 
->ARCs may also have a `extended-by` header indicating that functionalities has been added to the existing, still active ARC; the value is the number of the ARC that updates the current document.
-The newer ARC must have a `extends` header containing the number of the ARC that it rendered obsolete.
+>ARCs may also have an `extended-by` header indicating that functionalities have been added to the existing, still active ARC; the value is the number of the ARC that updates the current document.
+>The newer ARC must have an `extends` header containing the number of the ARC that it extends.
 
 
 ` * resolution:` *A url pointing to the resolution of this ARC*

--- a/ARCs/arc-0000.md
+++ b/ARCs/arc-0000.md
@@ -147,7 +147,13 @@ Each ARC must begin with an <a href="https://www.ietf.org/rfc/rfc822.txt">RFC 82
 >ARCs may have a `requires` header, indicating the ARC numbers that this ARC depends on.
 ` * replaces:` *ARC number(s)*
 ` * superseded-by:` *ARC number(s)*
->ARCs may also have a `superseded-by` header indicating that an ARC has been rendered obsolete by a later document; the value is the number of the ARC that replaces the current document. The newer ARC must have a `replaces` header containing the number of the ARC that it rendered obsolete.
+>ARCs may also have a `superseded-by` header indicating that an ARC has been rendered obsolete by a later document; the value is the number of the ARC that replaces the current document.
+>The newer ARC must have a `replaces` header containing the number of the ARC that it rendered obsolete.
+
+>ARCs may also have a `extended-by` header indicating that functionalities has been added to the existing, still active ARC; the value is the number of the ARC that updates the current document.
+The newer ARC must have a `extends` header containing the number of the ARC that it rendered obsolete.
+
+
 ` * resolution:` *A url pointing to the resolution of this ARC*
 
 Headers that permit lists must separate elements with commas.


### PR DESCRIPTION
We already had these 2 headers:
• superseded-by (only if Status is Deprecated): “To be used to refer to the newer ARC(s) that replace the older ARC.”
• replaces: “To be used to refer to an earlier ARC that is replaced by this ARC.”

The following are proposed to be added:
• extended-by: “To be used to refer to the newer ARC(s) that add functionality to the existing, still active ARC.”
• extends: “To be used as a reference from a new ARC that cannot be used independently.”