### PR TITLE
Arc 71- Fixed a text mistake

### DIFF
--- a/ARCs/arc-0071.md
+++ b/ARCs/arc-0071.md
@@ -51,7 +51,7 @@ The Issued state is the starting state of the ASA.The claimed state is when SBT 
 
 - The Creator parameter, the ASA **MAY** be created by any addresses.
 - The Clawback parameter **MUST** be the `ZeroAddress`.
-- The Freeze parameter **MUST** be set to the `ZeroAddress`.
+- The Freeze parameter **MUST** be set to the Issuer Address.
 - The Manager parameter **MAY** be set to any address but is **RECOMMENDED** to be the Issuer.
 - The Reserve parameter **MUST** be set to either [ARC-19](./arc-0019.md) metadata or SBT Issuer's address.
 
@@ -61,7 +61,7 @@ The Issued state is the starting state of the ASA.The claimed state is when SBT 
 - The Clawback parameter **MUST** be the `ZeroAddress`.
 - The Freeze parameter **MUST** be set to the `ZeroAddress`.
 - The asset must be frozen for holder (claimer) account address.
-- The Manager parameter **MAY** be set to any address but is **RECOMMENDED** to be the Issuer.
+- The Manager parameter  **MUST** be the Issuer Address.
 - The Reserve parameter **MUST** be set to either ARC-19 metadata or SBT Issuer's address.
 
 #### Revoked SoulBound ASA


### PR DESCRIPTION
Fixed the mistaken sentence and corrected to `The Freeze parameter **MUST** be set to the Issuer Address` for the Issued state of SBTs.