### PR TITLE
Fix typo in ARC-59

### DIFF
--- a/ARCs/arc-0059.md
+++ b/ARCs/arc-0059.md
@@ -204,7 +204,7 @@ This information can then be used to send the asset. An example of using this in
 
 ### Claiming an Asset
 
-When claiming an asset, the claimer **MUST** call `arc9_claim` to claim the asset from their inbox. This will transfer the asset to the claimer and any extra ALGO in the inbox will be sent to the claimer.
+When claiming an asset, the claimer **MUST** call `arc59_claim` to claim the asset from their inbox. This will transfer the asset to the claimer and any extra ALGO in the inbox will be sent to the claimer.
 
 Prior to sending the `arc59_claim` app call, a call to `arc59_claimAlgo` **SHOULD** be made to claim any extra ALGO in the inbox if the inbox balance is above its minimum balance.
 


### PR DESCRIPTION
Fixed the name of the claim method in the explanation of claiming an asset