### PR TITLE
ARC-83 Add Elgibility criteria for xGov Council

### DIFF
--- a/ARCs/arc-0083.md
+++ b/ARCs/arc-0083.md
@@ -49,6 +49,11 @@ The `status` field indicates the current status of the submission:
 
 ### xGov Council Duties and Powers
 
+#### Eligibility Criteria
+
+- Any Algorand holder, including xGovs, with Algorand technical expertise and/or a strong reputation can run for the council.
+- Candidates must disclose their real name, have an identified Algorand address, and undergo the KYC process with the Algorand Foundation.
+
 #### Duties
 
 - Review and understand the terms and conditions of the program.


### PR DESCRIPTION
Eligibility criteria:
* Any Algorand holder, including xGovs, with Algorand technical expertise and/or a strong reputation can run for the council.
* Candidates must disclose their real name, have an identified Algorand address, and undergo the KYC process with the Algorand Foundation.

based on https://forum.algorand.org/t/the-xgov-council-shaping-the-future-of-xgov/14035
