### PR TITLE
ARC-85: Revocable Decentralized Recovery (ReDeRec)

### DIFF
--- a/ARCs/arc-0085.md
+++ b/ARCs/arc-0085.md
@@ -1,9 +1,9 @@
 ---
 arc: 85
-title: Active DeRec
+title: Revocable Decentralized Recovery (ReDeRec)
 description: Revocable Decentralized Recovery protocol utilizing rekeying and multisigs instead of sharing mnemonic shards.
 author: Tasos Bitsios (@tasosbit)
-discussions-to: <URL>
+discussions-to: https://github.com/algorandfoundation/ARCs/pull/344
 status: Draft
 type: Standards Track
 category: ARC
@@ -12,7 +12,7 @@ created: 2025-06-18
 ---
 
 ## Abstract
-This ARC outlines a new approach to Decentralized Recovery which enables revocability. Instead of sharing private key shards with custodians, an Algorand account can be rekeyed to a specially crafted multisig so that the account owner can self-sign, and the recovery custodians can combine in a multisig threshold fashion (2/3, 3/4, etc) to help recover the account. Self-signing is enabled by repeating the owner account's keys in the subsigners field, in satisfy the threshold requirement as a standalone signer. Revoking custodians is as simple as rekeying to another multisig account.
+This ARC outlines a new approach to Decentralized Recovery which enables revocability. Instead of sharing private key shards with custodians, an Algorand account can be rekeyed to a specially crafted multisig so that the owner account can self-sign, and the recovery custodians can combine in a multisig threshold fashion (2/3, 3/4, etc) to help recover the account. Self-signing is enabled by repeating the owner account's key in the subsigners field, in order to satisfy the threshold requirement as a standalone signer. Revoking custodians is as simple as rekeying to another authorizer account.
 
 ## Motivation
 Sharing private key shards for decentralized recovery purposes is a concern that is worth addressing. This ARC improves upon the irrevocable nature of "classic" decentralized recovery by introducing an "active-state" method to achieve the same result without the potential for private key compromise if enough shards are compromised over time.

--- a/ARCs/arc-0085.md
+++ b/ARCs/arc-0085.md
@@ -1,0 +1,74 @@
+---
+arc: 85
+title: Active DeRec
+description: Revocable Decentralized Recovery protocol utilizing rekeying and multisigs instead of sharing mnemonic shards.
+author: Tasos Bitsios (@tasosbit)
+discussions-to: <URL>
+status: Draft
+type: Standards Track
+category: ARC
+subcategory: Wallet
+created: 2025-06-18
+---
+
+## Abstract
+This ARC outlines a new approach to Decentralized Recovery which enables revocability. Instead of sharing private key shards with custodians, an Algorand account can be rekeyed to a specially crafted multisig so that the account owner can self-sign, and the recovery custodians can combine in a multisig threshold fashion (2/3, 3/4, etc) to help recover the account. Self-signing is enabled by repeating the owner account's keys in the subsigners field, in satisfy the threshold requirement as a standalone signer. Revoking custodians is as simple as rekeying to another multisig account.
+
+## Motivation
+Sharing private key shards for decentralized recovery purposes is a concern that is worth addressing. This ARC improves upon the irrevocable nature of "classic" decentralized recovery by introducing an "active-state" method to achieve the same result without the potential for private key compromise if enough shards are compromised over time.
+
+## Specification
+The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC-2119</a>.
+
+An active decentralized recovery signer account is a multi-signature composed the owner account and the "custodian" accounts.
+
+- The Owner Account (OA) MUST be able to sign for transactions without requiring signatures from any other party.
+- Custodian accounts (CAs) MUST be able to sign for transactions when enough signatures are presented to meet the recovery threshold.
+- The recovery threshold (T) is the number of CA signatures required to recover an account.
+- The OA is repeated in the multisig sub-signers group T times, in order to be able to self-sign.
+
+Note: Algorand allows for a single-signature account to be rekeyed to a multisig wherein the single-sig is its own sub-signer, which enables users to use this pattern without requiring a new private key (and corresponding mnemonic to save.)
+
+Example: Alice wants to add Bob, Eve and Steve as recovery custodians to her account. She wants any 2 of the 3 custodians to be able to help her recover her account.
+
+Owner Account: `ALICE234..`
+
+Custodians:
+- `BOB345..`
+- `EVE456..`
+- `STEVE567..`
+
+Threshold: 2
+
+Multisig configuration:
+
+```
+{
+    version: 1,
+    threshold: 2,
+    addrs: [
+        "ALICE234..",
+        "ALICE234..",
+        "BOB345..",
+        "EVE456..",
+        "STEVE567..",
+    ]
+}
+```
+
+## Backwards Compatibility
+This method requires a wallet that supports rekeying and multi-signature accounts. Beyond that on-chain compatibility should be 100%, as transaction signature schemes are transparent as far as Applications are concerned. Off-chain systems validating account ownership for "login" functionality must be able to support multi-sig accounts.
+
+## Test Cases
+TODO
+
+## Reference Implementation
+TODO
+
+## Security Considerations
+Note that when accounts are closed out (i.e. taken to a zero ALGO balance) their rekeying status reverts to the default, so users of active DeRec are RECOMMENDED to maintain a minimum balance requirement above the base account MBR (0.1 ALGO) as a safety precaution against accidental close-outs.
+
+Availability of the custodian account private keys is not enforced in this standard. A periodic heartbeat mechanism could be built for CA subsigners to prove that their private keys are still available.
+
+## Copyright
+Copyright and related rights waived via <a href="https://creativecommons.org/publicdomain/zero/1.0/">CCO</a>.

--- a/ARCs/arc-0085.md
+++ b/ARCs/arc-0085.md
@@ -3,7 +3,7 @@ arc: 85
 title: Revocable Decentralized Recovery (ReDeRec)
 description: Revocable Decentralized Recovery protocol utilizing rekeying and multisigs instead of sharing mnemonic shards.
 author: Tasos Bitsios (@tasosbit)
-discussions-to: https://github.com/algorandfoundation/ARCs/pull/344
+discussions-to: https://github.com/algorandfoundation/ARCs/issues/344
 status: Draft
 type: Standards Track
 category: ARC


### PR DESCRIPTION
This ARC outlines a new approach to Decentralized Recovery which enables revocability.

Instead of sharing private key shards with custodians, an Algorand account can be rekeyed to a specially crafted multisig so that the owner account can self-sign, and the recovery accounts ("custodians") can combine in a multisig threshold fashion (2/3, 3/4, etc) to help recover the account.

Self-signing is enabled by repeating the owner account's keys in the subsigners field, in order to satisfy the threshold requirement as a standalone signer. Revoking custodians is as simple as rekeying to another account.

For those unfamiliar with GitHub, you can view an easily readable version of the proposal here: https://github.com/tasosbit/ARCs/blob/arc85-active-derec/ARCs/arc-0085.md

TODO:

[ ] Test cases
[ ] Reference Implementation?