### PR TITLE
Add deployments and ARC56 JSON to ARC59

### DIFF
--- a/ARCs/arc-0059.md
+++ b/ARCs/arc-0059.md
@@ -45,7 +45,16 @@ An application operator who wants to on-board users to their game or business ma
 
 The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC-2119</a>.
 
-### Router Contract Interface
+### Deployments
+
+This ARC works best when there is a singleton deployment per network. Below are the app IDs for the canonical deployments:
+
+| Network | App ID |
+| --- | --- |
+| Mainnet | `2449590623` |
+| Testnet | `643020148` |
+
+### Router Contract [ARC-56](./arc-0056.md) JSON
 
 ```json
 {
@@ -58,6 +67,10 @@ The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL 
       "args": [],
       "returns": {
         "type": "void"
+      },
+      "actions": {
+        "create": ["NoOp"],
+        "call": []
       }
     },
     {
@@ -72,6 +85,10 @@ The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL 
       ],
       "returns": {
         "type": "void"
+      },
+      "actions": {
+        "create": [],
+        "call": ["NoOp"]
       }
     },
     {
@@ -87,6 +104,10 @@ The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL 
       "returns": {
         "type": "address",
         "desc": "The inbox address"
+      },
+      "actions": {
+        "create": [],
+        "call": ["NoOp"]
       }
     },
     {
@@ -104,8 +125,13 @@ The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL 
         }
       ],
       "returns": {
-        "type": "(uint64,uint64,bool,bool,uint64)",
-        "desc": "Returns the following information for sending an asset:The number of itxns required, the MBR required, whether the router is opted in, and whether the receiver is opted in"
+        "type": "(uint64,uint64,bool,bool,uint64,uint64)",
+        "desc": "Returns the following information for sending an asset:\nThe number of itxns required, the MBR required, whether the router is opted in, whether the receiver is opted in,\nand how much ALGO the receiver would need to claim the asset",
+        "struct": "SendAssetInfo"
+      },
+      "actions": {
+        "create": [],
+        "call": ["NoOp"]
       }
     },
     {
@@ -131,6 +157,10 @@ The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL 
       "returns": {
         "type": "address",
         "desc": "The address that the asset was sent to (either the receiver or their inbox)"
+      },
+      "actions": {
+        "create": [],
+        "call": ["NoOp"]
       }
     },
     {
@@ -145,11 +175,15 @@ The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL 
       ],
       "returns": {
         "type": "void"
+      },
+      "actions": {
+        "create": [],
+        "call": ["NoOp"]
       }
     },
     {
       "name": "arc59_reject",
-      "desc": "Reject the ASA by closing it out to the ASA creator. Always sends two inner transactions.All non-MBR ALGO balance in the inbox will be sent to the caller.",
+      "desc": "Reject the ASA by closing it out to the ASA creator. Always sends two inner transactions.\nAll non-MBR ALGO balance in the inbox will be sent to the caller.",
       "args": [
         {
           "name": "asa",
@@ -159,6 +193,10 @@ The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL 
       ],
       "returns": {
         "type": "void"
+      },
+      "actions": {
+        "create": [],
+        "call": ["NoOp"]
       }
     },
     {
@@ -174,6 +212,10 @@ The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL 
       "returns": {
         "type": "address",
         "desc": "Zero address if the receiver does not yet have an inbox, otherwise the inbox address"
+      },
+      "actions": {
+        "create": [],
+        "call": ["NoOp"]
       }
     },
     {
@@ -182,11 +224,77 @@ The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL 
       "args": [],
       "returns": {
         "type": "void"
+      },
+      "actions": {
+        "create": [],
+        "call": ["NoOp"]
       }
     }
-  ]
+  ],
+  "arcs": [4, 56],
+  "structs": {
+    "SendAssetInfo": [
+      {
+        "name": "itxns",
+        "type": "uint64"
+      },
+      {
+        "name": "mbr",
+        "type": "uint64"
+      },
+      {
+        "name": "routerOptedIn",
+        "type": "bool"
+      },
+      {
+        "name": "receiverOptedIn",
+        "type": "bool"
+      },
+      {
+        "name": "receiverAlgoNeededForClaim",
+        "type": "uint64"
+      },
+      {
+        "name": "receiverAlgoNeededForWorstCaseClaim",
+        "type": "uint64"
+      }
+    ]
+  },
+  "state": {
+    "schema": {
+      "global": {
+        "bytes": 0,
+        "ints": 0
+      },
+      "local": {
+        "bytes": 0,
+        "ints": 0
+      }
+    },
+    "keys": {
+      "global": {},
+      "local": {},
+      "box": {}
+    },
+    "maps": {
+      "global": {},
+      "local": {},
+      "box": {
+        "inboxes": {
+          "keyType": "address",
+          "valueType": "address"
+        }
+      }
+    }
+  },
+  "bareActions": {
+    "create": [],
+    "call": []
+  }
 }
 ```
+
+**NOTE:** This ARC-56 spec does not include the source information, including error mapping, because the deployment used a version of TEALScript to compile the contract prior to ARC-56 support.
 
 ### Sending an Asset
 


### PR DESCRIPTION
Adds the ARC56 JSON and deployed app IDs to ARC59. Spec and functionality remain unchanged 