### PR TITLE
[ARC-86] Adding Mainnet registry id

### DIFF
--- a/ARCs/arc-0086.md
+++ b/ARCs/arc-0086.md
@@ -4,7 +4,8 @@ title: xGov status and voting power
 description: xGov status and voting power for the Algorand Governance
 author: Stéphane Barroso (@SudoWeezy), Adriana Belotti, Michele Treccani, Cosimo Bassi
 discussions-to: https://github.com/algorandfoundation/ARCs/issues/345
-status: Draft
+status: Last Call
+last-call-deadline: 2025-08-15
 type: Meta
 created: 2025-06-25
 ---
@@ -23,7 +24,7 @@ xGovs, or Expert Governors, are decision makers in the Algorand Expert Governanc
 
 These individuals can participate in the designation and approval of proposals submitted to the Algorand Expert Governance process.
 
-An xGov is associated with an Algorand Address subscribing to the Algorand Expert Governance by acknowledging the xGov Registry (Application ID: _TBD_).
+An xGov is associated with an Algorand Address subscribing to the Algorand Expert Governance by acknowledging the xGov Registry (Application ID: 3147789458).
 
 Once the xGov Registry confirms the acknowledgement, the xGov is eligible to acquire _voting power_.
 


### PR DESCRIPTION
Now that the Mainnet application is deployed, we can add it to the ARC. 