### PR TITLE
[ARC-90]Fix fragment to comply with arc 3

### DIFF
--- a/ARCs/arc-0090.md
+++ b/ARCs/arc-0090.md
@@ -190,26 +190,28 @@ algorand://net:unknown-net/asset/31566704?total
 
 Implementations that emit Algorand URIs and need to declare conformance with multiple ARC MUST encode that declaration in the URI fragment using the pattern `#arc<A>+<B>+<C>...`, where every letter represents an unpadded decimal ARC number listed in strictly ascending order. Only the first entry MAY carry the `arc` literal; subsequent entries MUST be bare numbers separated by `+` and no other separators or padding are allowed. For example, `#arc26+27` is valid, while `#arc26+arc27`, `#arc026+27`, and `#arc27+26` are invalid.
 
+**As a special case, declarations that include [ARC-3](./arc-0003.md) MUST list ARC-3 as the sole entry, using the fragment `#arc3` without any additional ARC identifiers.**
+
 Consumers of this scheme SHOULD treat fragments that do not follow this structure as non-compliant and ignore the multi-ARC declaration they attempt to convey.
 
 #### Example — Declaring Multi-ARC Compliance
 
 Implementations MAY use the URI fragment to indicate which ARC standards the resource conforms to.
 
-For example, an [ARC-16](./arc-0016.md) NFT asset that also follows the [ARC-3](./arc-0003.md) metadata conventions could expose a URI such as:
+The following illustration uses two hypothetical future ARCs. A resource that conforms to hypothetical ARC-X and ARC-Y could expose a URI such as:
 
-`algorand://app/123456?box=AAAAAAAAAAAAA#arc3+16`
-In this case, the fragment value `arc3+16` declares that the asset metadata conforms to both ARC-3 and ARC-16.
+`algorand://app/123456?box=AAAAAAAAAAAAA#arcX+Y`
+In this case, the fragment value `arcX+Y` declares that the asset metadata conforms to both hypothetical ARC-X and ARC-Y, where `X` and `Y` are ARC numbers.
 
 Clients interpreting this fragment SHOULD:
 
 1. Strip the `#arc` prefix and split the remainder by the `"+"` separator.  
-   Example: `"arc3+16"` → `[3, 16]`
+   Example: `"arcX+Y"` → `[X, Y]`
 2. Treat the resulting list as the set of supported ARC identifiers.  
 3. Optionally fetch or reference the corresponding ARC specification documents,  
    e.g.:  
-   - ARC-3
-   - ARC-16
+   - ARC-X (hypothetical)
+   - ARC-Y (hypothetical)
 4. Preserve order if present, though ARC numbers **SHOULD** be listed in ascending order for canonical form.  
    Clients **MUST** accept any order.
 

--- a/ARCs/arc-0090.md
+++ b/ARCs/arc-0090.md
@@ -4,8 +4,7 @@ title: URI scheme
 description: Consolidated specification for encoding Algorand transactions and queries as URIs.
 author: Fabrice Benhamouda (@fabrice102), Ben Guidarelli (@barnjamin), Tasos Bitsios (@tasosbit), MG (@emg110), Barroso Stéphane (@sudoweezy)
 discussions-to: https://github.com/algorandfoundation/ARCs/discussions/359
-status: Last Call
-last-call-deadline: 2025-12-15
+status: Final
 type: Standards Track
 category: Interface
 sub-category: General


### PR DESCRIPTION
Clarifies compliance fragment rules by explicitly requiring ARC-3 to appear alone as #arc3.

Reworks the multi-ARC example to use hypothetical ARC-X/ARC-Y identifiers and URI algorand://app/123456?box=AAAAAAAAAAAAA#arcX+Y.