### PR TITLE
ARC-89 - Nit typo fixes

### DIFF
--- a/ARCs/arc-0089.md
+++ b/ARCs/arc-0089.md
@@ -219,7 +219,7 @@ The Irreversible Flags (`byte`) are defined as follows:
 
 The `MSB` is the leftmost bit in the byte stored in Asset Metadata Box.
 
-The bits `2 ... 6` are reserved for future ARCs (default `False` if not used).
+The bits `3 ... 6` are reserved for future ARCs (default `False` if not used).
 
 The Metadata **MAY** be declared as [ARC-3](./arc-0003.md) compliant on creation
 setting the bit `LSB` in the Irreversible Flags to `True`.
@@ -264,7 +264,7 @@ Round **MUST** be updated on any modification of either:
 
 > The Last Modified Round is guaranteed to be monotonically increasing.
 
-#### Deprecated By
+##### Deprecated By
 
 The Deprecated By (`uint64`) is the Application ID of the new ASA Metadata Registry
 version.
@@ -1891,7 +1891,7 @@ The Algod clients retrieve the Asset Metadata from two entrypoints:
 
 1. The _Asset Metadata URI_.
 
-> A minimal <a href="https://github.com/algorandfoundation/arc89/tree/main/src/asa_metadata_registry">[Python SDK</a>.
+> A minimal <a href="https://github.com/algorandfoundation/arc89/tree/main/src/asa_metadata_registry">Python SDK</a>
 > is provided with the reference implementation.
 
 ##### Example 1: Get [ARC-3](./arc-0003.md) Metadata from the Asset ID


### PR DESCRIPTION
- Fix `Deprecated By` section heading level
- Fix misleading `[` in Python SDK link
- Correct empty irreversible flags from 2 to 3, to account for ARC-54 flag